### PR TITLE
nohup的使用考虑不周全

### DIFF
--- a/ngrinder-core/src/main/resources/shell/run_agent_bg.sh
+++ b/ngrinder-core/src/main/resources/shell/run_agent_bg.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 curpath=`dirname $0`
-nohup ${curpath}/run_agent.sh $1 &
+nohup ${curpath}/run_agent.sh $1 >> /tmp/ngrinder.log & 2>&1


### PR DESCRIPTION
nohup会默认将输出写到执行脚本时所在的目录，存在几个问题
1、用户不一定有执行时所在目录（pwd）的写入权限。若无，会导致由于nohup无法输入日志而脚本被迫终止
2、日志输出文件名为nohup默认，文件名没有任何意义，且日志位置太随意
