### PR TITLE
将Windows下NGRINDER_AGENT_HOME默认指到安装目录下

### DIFF
--- a/ngrinder-core/src/main/resources/shell/run_agent.bat
+++ b/ngrinder-core/src/main/resources/shell/run_agent.bat
@@ -1,5 +1,6 @@
 @ECHO OFF
 SET basedir=%~dp0
+SET NGRINDER_AGENT_HOME=%~dp0
 CD %basedir%
 
 :RUN


### PR DESCRIPTION
Windows下不允许建立 .ngrinder_agent 的目录或文件（属于没有文件名，只有后缀）。
官网的文档也要改 ：www.cubrid.org/wiki_ngrinder/entry/installation-guide
直接把这个配置指向到安装目录最好了，简单易用！然后给个默认的配置，降低使用门槛。
