### PR TITLE
#58 NullPointerException in ScriptConsoleControllerTest

### DIFF
--- a/ngrinder-controller/src/test/java/org/ngrinder/operation/MockScriptConsoleController.java
+++ b/ngrinder-controller/src/test/java/org/ngrinder/operation/MockScriptConsoleController.java
@@ -1,0 +1,24 @@
+/* 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. 
+ */
+package org.ngrinder.operation;
+
+import org.ngrinder.operation.cotroller.ScriptConsoleController;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Profile("unit-test")
+@Component
+public class MockScriptConsoleController extends ScriptConsoleController {
+
+}

--- a/ngrinder-controller/src/test/java/org/ngrinder/operation/ScriptConsoleControllerTest.java
+++ b/ngrinder-controller/src/test/java/org/ngrinder/operation/ScriptConsoleControllerTest.java
@@ -20,16 +20,16 @@ import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
 import org.ngrinder.AbstractNGrinderTransactionalTest;
-import org.ngrinder.operation.cotroller.ScriptConsoleController;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ui.ExtendedModelMap;
 import org.springframework.ui.Model;
 
 public class ScriptConsoleControllerTest extends AbstractNGrinderTransactionalTest {
+	@Autowired
+	MockScriptConsoleController scriptController;
 
 	@Test
 	public void runScriptTest() {
-		ScriptConsoleController scriptController = new ScriptConsoleController();
-
 		Model model = new ExtendedModelMap();
 		scriptController.run("", model);
 		assertThat((String) model.asMap().get("result"), nullValue());


### PR DESCRIPTION
ScriptConsoleController의 run메소드에서 UserContext를 사용하도록 수정되어
UserContext를 autowired할 수 있도록 수정하였습니다.