### PR TITLE
modify 3.3.1 planned release date

### DIFF
--- a/release_note.txt
+++ b/release_note.txt
@@ -1,4 +1,4 @@
-3.3.1 (2015.03.20)
+3.3.1 (2015.06.31/Planned)
 nGrinder 3.3.1 is the bug fix and minor enhancement release.
 
 Bug


### PR DESCRIPTION
In the release note, 3.3.1 version release data is mistakenly noted as 3.31. I changed it to the official planned date.