### PR TITLE
add builtin agent

### DIFF
--- a/docker/standalone/agent/.gitignore
+++ b/docker/standalone/agent/.gitignore
@@ -1,0 +1,1 @@
+ngrinder-agent-*.tar

--- a/docker/standalone/agent/Dockerfile
+++ b/docker/standalone/agent/Dockerfile
@@ -1,5 +1,6 @@
 FROM centos:centos6
-MAINTAINER Veronica Hong "rankyung.hong@gmail.com"
+MAINTAINER JunHo Yoon "junoyoon@gmail.com"
+
 
 # Install necessary packages
 RUN yum -y install wget tar vim java-1.7.0-openjdk-devel.x86_64
@@ -8,10 +9,13 @@ RUN yum -y install wget tar vim java-1.7.0-openjdk-devel.x86_64
 ENV BASE_DIR=/opt \
     AGENT_HOME=$BASE_DIR/ngrinder-agent \
     JAVA_HOME=/etc/alternatives/java_sdk \
-    PATH=$PATH:$JAVA_HOME/bin:$AGENT_HOME
+    PATH=$PATH:$JAVA_HOME/bin:$AGENT_HOME \
+    VERSION=3.3
+
+ADD ngrinder-agent-${VERSION}.tar $BASE_DIR/builtin
 
 # Copy initial excution script
 ADD scripts /scripts
 
 # Excution
-CMD ["/scripts/run.sh"]
+ENTRYPOINT ["/scripts/run.sh"]

--- a/docker/standalone/agent/README
+++ b/docker/standalone/agent/README
@@ -1,0 +1,4 @@
+Before build, locate ngrinder-agent-${VERSION}.tar file in this folderi deleteing __agent.conf file internally.
+This file is not version controlled because of the size.
+
+

--- a/docker/standalone/agent/scripts/run.sh
+++ b/docker/standalone/agent/scripts/run.sh
@@ -40,6 +40,9 @@ then
 		done
 	fi
 else
-	echo "Please set CONTROLLER_ADDR environment variable"
+	echo "CONTROLLE_ADDR environment varible is not set. Use the built in controller"
+	AGENT="${BASE_DIR}/builtin/ngrinder-agent"
+	cd ${AGENT}
+	${AGENT}/run_agent.sh "$@"
 fi
 


### PR DESCRIPTION
Use built in controller if the CONTROLLER_ADDR is not provided.

The basic usage is like below

docker run -it ngrinder/agent:3.3-p2 [agent execution arguments]