### PR TITLE
#114 make the travis skip the test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ before_install:
 jdk:
   - oraclejdk8
   - oraclejdk7
+script:
+  - mvn test -DskipTests=true


### PR DESCRIPTION
Travis is execute to the 'mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V' for build by default.
So we just need add script that skip test script instead to default test script.