### PR TITLE
#137 fix hibernate warning

### DIFF
--- a/ngrinder-starter/src/main/java/org/ngrinder/NGrinderControllerStarter.java
+++ b/ngrinder-starter/src/main/java/org/ngrinder/NGrinderControllerStarter.java
@@ -212,6 +212,7 @@ public class NGrinderControllerStarter {
 		Server server = new Server(port);
 		ServerConnector connector = new ServerConnector(server);
 		// Set some timeout options to make debugging easier.
+		connector.setIdleTimeout(1000 * 60 * 60);
 		connector.setSoLingerTime(-1);
 		connector.setPort(port);
 		server.setConnectors(new Connector[]{connector});


### PR DESCRIPTION
recover jetty timeout settings to reduce unnecessary timeout log