### PR TITLE
Feature/speed up page navigation

### DIFF
--- a/ngrinder-controller/pom.xml
+++ b/ngrinder-controller/pom.xml
@@ -278,7 +278,11 @@
 			<artifactId>hibernate-entitymanager</artifactId>
 			<version>4.2.2.Final</version>
 		</dependency>
-
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-ehcache</artifactId>
+			<version>4.2.2.Final</version>
+		</dependency>
 
 		<!-- AspectJ dependencies -->
 		<dependency>

--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/controller/PerfTestController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/controller/PerfTestController.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -9,7 +9,7 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License. 
+ * limitations under the License.
  */
 package org.ngrinder.perftest.controller;
 
@@ -137,11 +137,11 @@ public class PerfTestController extends BaseController {
 	                     @PageableDefault(page = 0, size = 10) Pageable pageable, ModelMap model) {
 		pageable = new PageRequest(pageable.getPageNumber(), pageable.getPageSize(),
 						defaultIfNull(pageable.getSort(),
-						new Sort(Direction.DESC, "lastModifiedDate")));
+						new Sort(Direction.DESC, "id")));
 		Page<PerfTest> tests = perfTestService.getPagedAll(user, query, tag, queryFilter, pageable);
 		if (tests.getNumberOfElements() == 0) {
 			pageable = new PageRequest(0, pageable.getPageSize(), defaultIfNull(pageable.getSort(),
-							new Sort(Direction.DESC, "lastModifiedDate")));
+							new Sort(Direction.DESC, "id")));
 			tests = perfTestService.getPagedAll(user, query, tag, queryFilter, pageable);
 		}
 		annotateDateMarker(tests);

--- a/ngrinder-controller/src/main/java/org/ngrinder/user/controller/UserController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/user/controller/UserController.java
@@ -162,7 +162,7 @@ public class UserController extends BaseController {
 	@RequestMapping("/profile")
 	public String getOne(User user, ModelMap model) {
 		checkNotEmpty(user.getUserId(), "UserID should not be NULL!");
-		User one = userService.getOne(user.getUserId());
+		User one = userService.getOneWithFollowers(user.getUserId());
 		model.addAttribute("user", one);
 		model.addAttribute("allowPasswordChange", !config.isDemo());
 		model.addAttribute("allowRoleChange", false);

--- a/ngrinder-controller/src/main/java/org/ngrinder/user/controller/UserController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/user/controller/UserController.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -9,7 +9,7 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License. 
+ * limitations under the License.
  */
 package org.ngrinder.user.controller;
 
@@ -261,18 +261,16 @@ public class UserController extends BaseController {
 
 
 	private List<UserSearchResult> getSwitchableUsers(User user, String keywords) {
-		List<UserSearchResult> result = newArrayList();
 		if (user.getRole().hasPermission(Permission.SWITCH_TO_ANYONE)) {
+			List<UserSearchResult> result = newArrayList();
 			for (User each : userService.getPagedAll(keywords, new PageRequest(0, 10))) {
 				result.add(new UserSearchResult(each));
 			}
+			return result;
 		} else {
-			User currUser = userService.getOne(user.getUserId());
-			for (User each : currUser.getOwners()) {
-				result.add(new UserSearchResult(each));
-			}
+			return userService.getSharedUser(user);
 		}
-		return result;
+
 	}
 
 
@@ -415,8 +413,8 @@ public class UserController extends BaseController {
 	public HttpEntity<String> search(User user, @PageableDefault Pageable pageable,
 	                                 @RequestParam(required = true) String keywords) {
 		pageable = new PageRequest(pageable.getPageNumber(), pageable.getPageSize(),
-				defaultIfNull(pageable.getSort(),
-						new Sort(Direction.ASC, "userName")));
+			defaultIfNull(pageable.getSort(),
+				new Sort(Direction.ASC, "userName")));
 		Page<User> pagedUser = userService.getPagedAll(keywords, pageable);
 		List<UserSearchResult> result = newArrayList();
 		for (User each : pagedUser) {

--- a/ngrinder-controller/src/main/java/org/ngrinder/user/service/UserService.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/user/service/UserService.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -9,7 +9,7 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License. 
+ * limitations under the License.
  */
 package org.ngrinder.user.service;
 
@@ -24,6 +24,7 @@ import org.ngrinder.perftest.service.PerfTestService;
 import org.ngrinder.script.service.FileEntryService;
 import org.ngrinder.security.SecuredUser;
 import org.ngrinder.service.AbstractUserService;
+import org.ngrinder.user.controller.UserController;
 import org.ngrinder.user.repository.UserRepository;
 import org.ngrinder.user.repository.UserSpecification;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -270,4 +271,13 @@ public class UserService extends AbstractUserService {
 	}
 
 
+	@Transactional
+	public List<UserController.UserSearchResult> getSharedUser(User user) {
+		List<UserController.UserSearchResult> result = new ArrayList<UserController.UserSearchResult>();
+		User currUser = getOne(user.getUserId());
+		for (User each : currUser.getOwners()) {
+			result.add(new UserController.UserSearchResult(each));
+		}
+		return result;
+	}
 }

--- a/ngrinder-controller/src/main/resources/META-INF/persistence.xml
+++ b/ngrinder-controller/src/main/resources/META-INF/persistence.xml
@@ -7,6 +7,9 @@
 			<property name="hibernate.format_sql" value="true" />
 			<property name="hibernate.hbm2ddl.auto" value="validate" />
 			<property name="hibernate.connection.release_mode" value="on_close"/>
+			<property name="hibernate.max_fetch_depth" value="0"/>
+			<property name="hibernate.cache.use_second_level_cache" value="true"/>
+			<property name="hibernate.cache.region.factory_class" value="org.hibernate.cache.ehcache.EhCacheRegionFactory"/>
 		</properties>
 	</persistence-unit> 
 </persistence>

--- a/ngrinder-controller/src/main/resources/ehcache-dist.xml
+++ b/ngrinder-controller/src/main/resources/ehcache-dist.xml
@@ -16,14 +16,21 @@
 		cluster. -->
 
 
-	<cache name="users" maxElementsInMemory="100" eternal="false"
-		   overflowToDisk="false" timeToIdleSeconds="30" timeToLiveSeconds="30">
+	<cache name="users" maxElementsInMemory="1000" eternal="false"
+		   overflowToDisk="false" timeToIdleSeconds="60" timeToLiveSeconds="60">
 		<cacheEventListenerFactory
 				class="net.sf.ehcache.distribution.RMICacheReplicatorFactory"
 				properties="replicateAsynchronously=false, replicatePuts=false, replicateUpdates=true, replicateUpdatesViaCopy=false, replicateRemovals=true"/>
 	</cache>
 
-	<cache name="file_entries" maxElementsInMemory="100"
+	<cache name="org.ngrinder.model.User" maxElementsInMemory="1000" eternal="false"
+		   overflowToDisk="false" timeToIdleSeconds="60" timeToLiveSeconds="60">
+		<cacheEventListenerFactory
+				class="net.sf.ehcache.distribution.RMICacheReplicatorFactory"
+				properties="replicateAsynchronously=false, replicatePuts=false, replicateUpdates=true, replicateUpdatesViaCopy=false, replicateRemovals=true"/>
+	</cache>
+
+	<cache name="file_entries" maxElementsInMemory="1000"
 		   eternal="false" overflowToDisk="false" timeToIdleSeconds="6000"
 		   timeToLiveSeconds="6000">
 		<cacheEventListenerFactory
@@ -31,7 +38,7 @@
 				properties="replicateAsynchronously=true, replicatePuts=false, replicateUpdates=false, replicateUpdatesViaCopy=false, replicateRemovals=true"/>
 	</cache>
 
-	<cache name="regions" maxElementsInMemory="100" overflowToDisk="false" eternal="false" timeToLiveSeconds="30">
+	<cache name="regions" maxElementsInMemory="1000" overflowToDisk="false" eternal="false" timeToLiveSeconds="30">
 		<cacheEventListenerFactory
 				class="net.sf.ehcache.distribution.RMICacheReplicatorFactory"
 				properties="replicateAsynchronously=true, replicatePuts=true, replicateUpdates=true, replicateUpdatesViaCopy=true, replicateRemovals=false"/>

--- a/ngrinder-controller/src/main/resources/ehcache.xml
+++ b/ngrinder-controller/src/main/resources/ehcache.xml
@@ -7,6 +7,11 @@
 	<cache name="users" maxElementsInMemory="100" eternal="false" overflowToDisk="false" timeToIdleSeconds="30"
 		   timeToLiveSeconds="30"/>
 
+	<cache name="org.ngrinder.model.User" maxElementsInMemory="100" eternal="false"
+		   overflowToDisk="false" timeToIdleSeconds="1" timeToLiveSeconds="1">
+	</cache>
+
+
 	<cache name="file_entries" maxElementsInMemory="100" eternal="false" overflowToDisk="false"
 		   timeToIdleSeconds="6000" timeToLiveSeconds="6000"/>
 	<cache name="right_panel_entries" maxElementsInMemory="2" eternal="false" overflowToDisk="false"

--- a/ngrinder-core/src/main/java/org/ngrinder/model/User.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/model/User.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -9,7 +9,7 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License. 
+ * limitations under the License.
  */
 package org.ngrinder.model;
 
@@ -91,12 +91,12 @@ public class User extends BaseModel<User> {
 	@Transient
 	private User ownerUser;
 
-	@ManyToMany(fetch = FetchType.EAGER)
+	@ManyToMany(fetch = FetchType.LAZY)
 	@JoinTable(name = "SHARED_USER", joinColumns = @JoinColumn(name = "owner_id"), // LF
 			inverseJoinColumns = @JoinColumn(name = "follow_id"))
 	private List<User> followers;
 
-	@ManyToMany(fetch = FetchType.EAGER)
+	@ManyToMany(fetch = FetchType.LAZY)
 	@JoinTable(name = "SHARED_USER", joinColumns = @JoinColumn(name = "follow_id"), // LF
 			inverseJoinColumns = @JoinColumn(name = "owner_id"))
 	private List<User> owners;

--- a/ngrinder-core/src/main/java/org/ngrinder/model/User.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/model/User.java
@@ -15,6 +15,7 @@ package org.ngrinder.model;
 
 import com.google.gson.annotations.Expose;
 import org.apache.commons.lang.StringUtils;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Type;
 
 import javax.persistence.*;
@@ -29,6 +30,8 @@ import static org.ngrinder.common.util.AccessUtils.getSafe;
  * @since 3.0
  */
 @Entity
+@Cacheable
+@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @Table(name = "NUSER")
 public class User extends BaseModel<User> {
 
@@ -93,12 +96,12 @@ public class User extends BaseModel<User> {
 
 	@ManyToMany(fetch = FetchType.LAZY)
 	@JoinTable(name = "SHARED_USER", joinColumns = @JoinColumn(name = "owner_id"), // LF
-			inverseJoinColumns = @JoinColumn(name = "follow_id"))
+		inverseJoinColumns = @JoinColumn(name = "follow_id"))
 	private List<User> followers;
 
 	@ManyToMany(fetch = FetchType.LAZY)
 	@JoinTable(name = "SHARED_USER", joinColumns = @JoinColumn(name = "follow_id"), // LF
-			inverseJoinColumns = @JoinColumn(name = "owner_id"))
+		inverseJoinColumns = @JoinColumn(name = "owner_id"))
 	private List<User> owners;
 
 	/**


### PR DESCRIPTION
Speed up the page navigation when there are much users setting followers.

We introduced followings.
* Not use EAGER fetching but LAZY in JPA
* Use Hibernate 2nd Level Cache not to query user
* Use id for perftest ordering instead of modified date (modified data requires full search)