### PR TITLE
Add system configuration for setting security level

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/common/constant/ControllerConstants.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/common/constant/ControllerConstants.java
@@ -68,6 +68,7 @@ public interface ControllerConstants {
 	public static final String PROP_CONTROLLER_SAFE_DIST = "controller.safe_dist";
 	public static final String PROP_CONTROLLER_SAFE_DIST_THRESHOLD = "controller.safe_dist_threshold";
 	public static final String PROP_CONTROLLER_SECURITY = "controller.security";
+	public static final String PROP_CONTROLLER_SECURITY_LEVEL = "controller.security.level";
 	public static final String PROP_CONTROLLER_URL = "controller.url";
 	public static final String PROP_CONTROLLER_VALIDATION_SYNTAX_CHECK = "controller.validation_syntax_check";
 	public static final String PROP_CONTROLLER_USAGE_REPORT = "controller.usage_report";

--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/config/Config.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/config/Config.java
@@ -57,6 +57,7 @@ import java.util.Properties;
 
 import static net.grinder.util.NoOp.noOp;
 import static org.ngrinder.common.constant.DatabaseConstants.PROP_DATABASE_UNIT_TEST;
+import static org.ngrinder.common.constants.GrinderConstants.GRINDER_SECURITY_LEVEL_NORMAL;
 import static org.ngrinder.common.util.Preconditions.checkNotNull;
 
 /**
@@ -551,6 +552,15 @@ public class Config extends AbstractConfig implements ControllerConstants, Clust
 	 */
 	public boolean isSecurityEnabled() {
 		return !isDevMode() && getControllerProperties().getPropertyBoolean(PROP_CONTROLLER_SECURITY);
+	}
+
+	/**
+	 * Get system security level from system properties.
+	 *
+	 * @return security level.
+	 */
+	public String getSecurityLevel() {
+		return getControllerProperties().getProperty(PROP_CONTROLLER_SECURITY_LEVEL, GRINDER_SECURITY_LEVEL_NORMAL);
 	}
 
 	/**

--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/PerfTestService.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/PerfTestService.java
@@ -612,6 +612,7 @@ public class PerfTestService extends AbstractPerfTestService implements Controll
 			grinderProperties.setProperty(GRINDER_PROP_JVM_CLASSPATH, getCustomClassPath(perfTest));
 			grinderProperties.setInt(GRINDER_PROP_IGNORE_SAMPLE_COUNT, getSafe(perfTest.getIgnoreSampleCount()));
 			grinderProperties.setBoolean(GRINDER_PROP_SECURITY, config.isSecurityEnabled());
+			grinderProperties.setProperty(GRINDER_PROP_SECURITY_LEVEL,  config.getSecurityLevel());
 			// For backward agent compatibility.
 			// If the security is not enabled, pass it as jvm argument.
 			// If enabled, pass it to grinder.param. In this case, I drop the

--- a/ngrinder-controller/src/main/java/org/ngrinder/script/service/ScriptValidationService.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/script/service/ScriptValidationService.java
@@ -112,7 +112,7 @@ public class ScriptValidationService extends AbstractScriptValidationService {
 						StringUtils.defaultIfBlank(scriptEntry.getEncoding(), "UTF-8"));
 			}
 			File doValidate = localScriptTestDriveService.doValidate(scriptDirectory, scriptFile, new Condition(),
-					config.isSecurityEnabled(), hostString, getTimeout());
+					config.isSecurityEnabled(), config.getSecurityLevel(), hostString, getTimeout());
 			List<String> readLines = FileUtils.readLines(doValidate);
 			StringBuilder output = new StringBuilder();
 			String path = config.getHome().getDirectory().getAbsolutePath();

--- a/ngrinder-controller/src/main/resources/controller-properties.map
+++ b/ngrinder-controller/src/main/resources/controller-properties.map
@@ -2,6 +2,7 @@ controller.verbose,false,verbose
 controller.dev_mode,false,testmode
 controller.demo_mode,false,demo
 controller.security,false,security
+controller.security.level,normal,
 controller.user_password_sha256,false,ngrinder.security.sha256
 controller.usage_report,true,usage.report
 controller.plugin_support,true,pluginsupport

--- a/ngrinder-controller/src/main/resources/ngrinder_home_template/system.conf
+++ b/ngrinder-controller/src/main/resources/ngrinder_home_template/system.conf
@@ -10,6 +10,10 @@
 # true if enabling security manager. The default value is false
 #controller.security=false
 
+# Determine security level of security manager. It only works if controller.security is true.
+# If you set 'controller.security.level=light', The less security will be applied. The default value is normal.
+#controller.security.level=normal
+
 # true if the password change should not be allowed.
 #controller.demo_mode=false
 

--- a/ngrinder-controller/src/test/java/org/ngrinder/script/service/ScriptValidationServiceTest.java
+++ b/ngrinder-controller/src/test/java/org/ngrinder/script/service/ScriptValidationServiceTest.java
@@ -15,6 +15,7 @@ package org.ngrinder.script.service;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
+import static org.ngrinder.common.constants.GrinderConstants.GRINDER_SECURITY_LEVEL_NORMAL;
 
 import java.io.File;
 import java.io.IOException;
@@ -83,7 +84,7 @@ public class ScriptValidationServiceTest extends AbstractNGrinderTransactionalTe
 	public void testValidation() throws EngineException, DirectoryException, IOException {
 		File file = new ClassPathResource("/validation/script_1time.py").getFile();
 		Condition m_eventSync = new Condition();
-		File log = validationService.doValidate(file.getParentFile(), file, m_eventSync, false, "");
+		File log = validationService.doValidate(file.getParentFile(), file, m_eventSync, false, GRINDER_SECURITY_LEVEL_NORMAL, "");
 		assertThat(log.length(), greaterThan(1000L));
 	}
 

--- a/ngrinder-core/src/main/java/net/grinder/engine/agent/AgentImplementationEx.java
+++ b/ngrinder-core/src/main/java/net/grinder/engine/agent/AgentImplementationEx.java
@@ -53,6 +53,8 @@ import java.util.Properties;
 import java.util.Timer;
 import java.util.TimerTask;
 
+import static org.ngrinder.common.constants.GrinderConstants.*;
+
 /**
  * This is the entry point of The Grinder agent process.
  *
@@ -367,7 +369,7 @@ public class AgentImplementationEx implements Agent, AgentConstants {
 	private String buildTestRunProperties(ScriptLocation script, AbstractLanguageHandler handler, Properties systemProperty,
 	                                      GrinderProperties properties) {
 		PropertyBuilder builder = new PropertyBuilder(properties, script.getDirectory(), properties.getBoolean(
-				"grinder.security", false), properties.getProperty("ngrinder.etc.hosts"),
+				GRINDER_PROP_SECURITY, false), properties.getProperty(GRINDER_PROP_SECURITY_LEVEL, GRINDER_SECURITY_LEVEL_NORMAL), properties.getProperty(GRINDER_PROP_ETC_HOSTS),
 				NetworkUtils.getLocalHostName(), m_agentConfig.getAgentProperties().getPropertyBoolean(PROP_AGENT_SERVER_MODE),
 				m_agentConfig.getAgentProperties().getPropertyBoolean(PROP_AGENT_LIMIT_XMX),
 				m_agentConfig.getAgentProperties().getPropertyBoolean(PROP_AGENT_ENABLE_LOCAL_DNS),

--- a/ngrinder-core/src/main/java/net/grinder/engine/agent/LocalScriptTestDriveService.java
+++ b/ngrinder-core/src/main/java/net/grinder/engine/agent/LocalScriptTestDriveService.java
@@ -59,8 +59,8 @@ public class LocalScriptTestDriveService {
 	 * @return File which stores validation result.
 	 */
 	public File doValidate(File base, File script, Condition eventSynchronisation, boolean securityEnabled,
-	                       String hostString) {
-		return doValidate(base, script, eventSynchronisation, securityEnabled, hostString, getDefaultTimeout());
+						   String securityLevel, String hostString) {
+		return doValidate(base, script, eventSynchronisation, securityEnabled, securityLevel, hostString, getDefaultTimeout());
 	}
 
 	protected int getDefaultTimeout() {
@@ -80,7 +80,7 @@ public class LocalScriptTestDriveService {
 	 */
 	@SuppressWarnings("SynchronizationOnLocalVariableOrMethodParameter")
 	public File doValidate(File base, File script, Condition eventSynchronisation, boolean securityEnabled,
-	                       String hostString, final int timeout) {
+						   String securityLevel, String hostString, final int timeout) {
 		FanOutStreamSender fanOutStreamSender = null;
 		ErrorStreamRedirectWorkerLauncher workerLauncher = null;
 		boolean stopByTooMuchExecution = false;
@@ -94,8 +94,8 @@ public class LocalScriptTestDriveService {
 			AbstractLanguageHandler handler = Lang.getByFileName(script).getHandler();
 			AbstractGrinderClassPathProcessor classPathProcessor = handler.getClassPathProcessor();
 			GrinderProperties properties = new GrinderProperties();
-			PropertyBuilder builder = new PropertyBuilder(properties, new Directory(base), securityEnabled, hostString,
-					NetworkUtils.getLocalHostName());
+			PropertyBuilder builder = new PropertyBuilder(properties, new Directory(base), securityEnabled, securityLevel, hostString,
+				NetworkUtils.getLocalHostName());
 			properties.setInt("grinder.agents", 1);
 			properties.setInt("grinder.processes", 1);
 			properties.setInt("grinder.threads", 1);

--- a/ngrinder-core/src/main/java/net/grinder/engine/agent/PropertyBuilder.java
+++ b/ngrinder-core/src/main/java/net/grinder/engine/agent/PropertyBuilder.java
@@ -30,6 +30,7 @@ import java.io.FilenameFilter;
 import java.net.InetAddress;
 import java.util.List;
 
+import static org.ngrinder.common.constants.GrinderConstants.GRINDER_SECURITY_LEVEL_LIGHT;
 import static org.ngrinder.common.util.Preconditions.checkNotEmpty;
 import static org.ngrinder.common.util.Preconditions.checkNotNull;
 
@@ -48,6 +49,7 @@ public class PropertyBuilder {
 	private final Directory baseDirectory;
 	private final String hostName;
 	private final boolean securityEnabled;
+	private final String securityLevel;
 	private final String hostString;
 	private final boolean server;
 	private final boolean useXmxLimit;
@@ -69,12 +71,13 @@ public class PropertyBuilder {
 	 * @param additionalJavaOpt additional java option to be provided when invoking agent
 	 *                          process
 	 */
-	public PropertyBuilder(GrinderProperties properties, Directory baseDirectory, boolean securityEnabled,
+	public PropertyBuilder(GrinderProperties properties, Directory baseDirectory, boolean securityEnabled, String securityLevel,
 						   String hostString, String hostName, boolean server, boolean useXmxLimit, boolean enableLocalDNS, String additionalJavaOpt) {
 		this.enableLocalDNS = enableLocalDNS;
 		this.properties = checkNotNull(properties);
 		this.baseDirectory = checkNotNull(baseDirectory);
 		this.securityEnabled = securityEnabled;
+		this.securityLevel = securityLevel;
 		this.hostString = hostString;
 		this.hostName = checkNotEmpty(hostName);
 		this.server = server;
@@ -95,9 +98,9 @@ public class PropertyBuilder {
 	 * @param additionalJavaOpt additional java option to be provided when invoking agent
 	 *                          process
 	 */
-	public PropertyBuilder(GrinderProperties properties, Directory baseDirectory, boolean securityEnabled,
+	public PropertyBuilder(GrinderProperties properties, Directory baseDirectory, boolean securityEnabled, String securityLevel,
 						   String hostString, String hostName, boolean server, boolean useXmxLimit, String additionalJavaOpt) {
-		this(properties, baseDirectory, securityEnabled, hostString, hostName, server, useXmxLimit, true, additionalJavaOpt);
+		this(properties, baseDirectory, securityEnabled, securityLevel, hostString, hostName, server, useXmxLimit, true, additionalJavaOpt);
 	}
 
 	/**
@@ -111,9 +114,9 @@ public class PropertyBuilder {
 	 * @param server          server mode
 	 * @param useXmxLimit     true if 1G limit should be enabled
 	 */
-	public PropertyBuilder(GrinderProperties properties, Directory baseDirectory, boolean securityEnabled,
+	public PropertyBuilder(GrinderProperties properties, Directory baseDirectory, boolean securityEnabled, String securityLevel,
 						   String hostString, String hostName, boolean server, boolean useXmxLimit) {
-		this(properties, baseDirectory, securityEnabled, hostString, hostName, server, useXmxLimit, null);
+		this(properties, baseDirectory, securityEnabled, securityLevel, hostString, hostName, server, useXmxLimit, null);
 	}
 
 	/**
@@ -127,8 +130,8 @@ public class PropertyBuilder {
 	 * @param server          server mode
 	 */
 	public PropertyBuilder(GrinderProperties properties, Directory baseDirectory, boolean securityEnabled,
-						   String hostString, String hostName, boolean server) {
-		this(properties, baseDirectory, securityEnabled, hostString, hostName, server, true);
+						   String securityLevel, String hostString, String hostName, boolean server) {
+		this(properties, baseDirectory, securityEnabled, securityLevel, hostString, hostName, server, true);
 	}
 
 	/**
@@ -141,8 +144,8 @@ public class PropertyBuilder {
 	 * @param hostName        current host name
 	 */
 	public PropertyBuilder(GrinderProperties properties, Directory baseDirectory, boolean securityEnabled,
-						   String hostString, String hostName) {
-		this(properties, baseDirectory, securityEnabled, hostString, hostName, false);
+						   String securityLevel, String hostString, String hostName) {
+		this(properties, baseDirectory, securityEnabled, securityLevel, hostString, hostName, false);
 	}
 
 	/**
@@ -248,7 +251,15 @@ public class PropertyBuilder {
 	}
 
 	protected StringBuilder addSecurityManager(StringBuilder jvmArguments) {
-		return jvmArguments.append(" -Djava.security.manager=org.ngrinder.sm.NGrinderSecurityManager ");
+		return jvmArguments.append(" -Djava.security.manager=" + getSecurityManagerBySecurityLevel(securityLevel) + " ");
+	}
+
+	private String getSecurityManagerBySecurityLevel(String securityLevel) {
+		if (GRINDER_SECURITY_LEVEL_LIGHT.equalsIgnoreCase(securityLevel)) {
+			return "org.ngrinder.sm.NGrinderLightSecurityManager";
+		} else {
+			return "org.ngrinder.sm.NGrinderSecurityManager";
+		}
 	}
 
 	private String getPath(File file, boolean useAbsolutePath) {

--- a/ngrinder-core/src/main/java/org/ngrinder/common/constants/GrinderConstants.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/common/constants/GrinderConstants.java
@@ -41,8 +41,11 @@ public interface GrinderConstants {
 	public static final String GRINDER_PROP_TEST_ID = "grinder.test.id";
 	public static final String GRINDER_PROP_IGNORE_SAMPLE_COUNT = "grinder.ignoreSampleCount";
 	public static final String GRINDER_PROP_SECURITY = "grinder.security";
+	public static final String GRINDER_PROP_SECURITY_LEVEL = "grinder.security.level";
 	public static final String GRINDER_PROP_USER = "grinder.user";
 	public static final String GRINDER_PROP_ETC_HOSTS = "ngrinder.etc.hosts";
+	public static final String GRINDER_SECURITY_LEVEL_LIGHT = "light";
+	public static final String GRINDER_SECURITY_LEVEL_NORMAL = "normal";
 	public static final String DEFAULT_GRINDER_PROPERTIES = "grinder.properties";
 
 }

--- a/ngrinder-core/src/test/java/net/grinder/engine/agent/PropertyBuilderTest.java
+++ b/ngrinder-core/src/test/java/net/grinder/engine/agent/PropertyBuilderTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.ngrinder.common.constants.GrinderConstants.GRINDER_SECURITY_LEVEL_NORMAL;
 
 import java.io.File;
 
@@ -66,6 +67,6 @@ public class PropertyBuilderTest {
 		Directory directory = new Directory(new File("."));
 		GrinderProperties property = new GrinderProperties();
 
-		return new PropertyBuilder(property, directory, true, hostString, NetworkUtils.getLocalHostName());
+		return new PropertyBuilder(property, directory, true, GRINDER_SECURITY_LEVEL_NORMAL, hostString, NetworkUtils.getLocalHostName());
 	}
 }

--- a/ngrinder-runtime/src/main/java/org/ngrinder/sm/NGrinderLightSecurityManager.java
+++ b/ngrinder-runtime/src/main/java/org/ngrinder/sm/NGrinderLightSecurityManager.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ngrinder.sm;
+
+import java.net.InetAddress;
+
+/**
+ * nGrinder security manager which less secured than NGrinderSecurityManager.
+ * <p/>
+ * This allows followings.
+ * <p/>
+ * <ul>
+ * <li>multicast</li>
+ * <li>tcp connection unspecified address</li>
+ * </ul>
+ *
+ * @since 3.4.2
+ */
+public class NGrinderLightSecurityManager extends NGrinderSecurityManager {
+
+	@Override
+	public void checkMulticast(InetAddress maddr) {
+	}
+
+	@Override
+	public void checkConnect(String host, int port) {
+	}
+
+	@Override
+	public void checkConnect(String host, int port, Object context) {
+	}
+}


### PR DESCRIPTION
## Distinguish nGrinder's security level
To distinguish nGrinder's security level I add NGrinderLightSecurityManager which less secured than NGrinderSecurityManager.

This allows followings.(not allowed in NGrinderSecurityManager.)

**1. multicast
2. tcp connection unspecified address**

If you want to use this, set 'controller.security.level=light'. It only works if controller.security is true.
 
The default value for this configuration is 'controller.security.level=normal'.
(using NGrinderSecurityManager.)