### PR TITLE
Remove context path from  AjaxObj url

### DIFF
--- a/ngrinder-controller/src/main/webapp/WEB-INF/ftl/perftest/basic_report.ftl
+++ b/ngrinder-controller/src/main/webapp/WEB-INF/ftl/perftest/basic_report.ftl
@@ -105,7 +105,7 @@
 	$("#leave_comment_btn").click(function(){
 		var comment = $("#test_comment").val();
 		var tagString = buildTagString();
-		var ajaxObj = new AjaxPostObj("${req.getContextPath()}/perftest/${(test.id)?c}/leave_comment",
+		var ajaxObj = new AjaxPostObj("/perftest/${(test.id)?c}/leave_comment",
 				{ "testComment": comment, "tagString":tagString },
 				"<@spring.message "perfTest.report.message.leaveComment"/>"
 		);

--- a/ngrinder-controller/src/main/webapp/WEB-INF/ftl/perftest/detail.ftl
+++ b/ngrinder-controller/src/main/webapp/WEB-INF/ftl/perftest/detail.ftl
@@ -1250,7 +1250,7 @@ function callUpdateAvailableAgentInfo() {
 }
 
 function updateAvailableAgentInfo(targetRegion) {
-    var ajaxObj = new AjaxObj("${req.getContextPath()}/agent/api/availableAgentCount");
+    var ajaxObj = new AjaxObj("/agent/api/availableAgentCount");
     ajaxObj.type = "GET";
     ajaxObj.params = {"targetRegion": targetRegion };
     ajaxObj.success = function (data) {

--- a/ngrinder-controller/src/main/webapp/WEB-INF/ftl/perftest/list.ftl
+++ b/ngrinder-controller/src/main/webapp/WEB-INF/ftl/perftest/list.ftl
@@ -468,7 +468,7 @@ function deleteTests(ids) {
 }
 
 function stopTests(ids) {
-	var ajaxObj = new AjaxObj("${req.getContextPath()}/perftest/api?action=stop",
+	var ajaxObj = new AjaxObj("/perftest/api?action=stop",
 			"<@spring.message "perfTest.message.stop.success"/>",
 			"<@spring.message "perfTest.message.stop.error"/>");
 	ajaxObj.type = "PUT";
@@ -520,7 +520,7 @@ function updateStatus(id, status, statusId, icon, stoppable, deletable, reportab
 			ids.push($each.val());
 		}
 	});
-	var ajaxObj = new AjaxObj("${req.getContextPath()}/perftest/api/status");
+	var ajaxObj = new AjaxObj("/perftest/api/status");
 	ajaxObj.type = "GET";
 	ajaxObj.params = {"ids": ids.join(",")};
 	ajaxObj.success = function (data) {


### PR DESCRIPTION
Remove context path from url parameter when creating AjaxObj

This problem causes the duplicated context path when running nGrinder under a specific context path.

This problem was issued by @lingsoul. Thx.