### PR TITLE
Remove JDK7 build in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,5 @@ before_install:
   - ./install_maven_lib.sh
 jdk:
   - oraclejdk8
-  - oraclejdk7
 script:
   - mvn test -DskipTests=true


### PR DESCRIPTION
JDK7 is quite old so we might not  need to build against JDK7.
I removed it out.