### PR TITLE
Changed jdk from oraclejdk to openjdk in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: java
 before_install:
   - ./install_maven_lib.sh
 jdk:
-  - oraclejdk8
+  - openjdk8
 script:
   - mvn test -DskipTests=true


### PR DESCRIPTION
Changed jdk from oraclejdk to openjdk. Because openjdk is more common than oraclejdk.