### PR TITLE
Use java1.7 for minimum running env

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,8 @@
 		<ngrinder.version>${project.version}</ngrinder.version>
 		<altDeploymentRepository>ngrinder::default::file:../ngrinder.maven.repo/releases</altDeploymentRepository>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.6</maven.compiler.source>
-		<maven.compiler.target>1.6</maven.compiler.target>
+		<maven.compiler.source>1.7</maven.compiler.source>
+		<maven.compiler.target>1.7</maven.compiler.target>
 		<jetty.version>9.2.17.v20160517</jetty.version>
 	</properties>
 


### PR DESCRIPTION
Use java 1.7 for minimum running JDK env.
Drop java 1.6 which released 2006. I think it's time to drop it.