### PR TITLE
Provide limited agent management menu for user permission

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/common/util/SpringSecurityUtils.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/common/util/SpringSecurityUtils.java
@@ -1,0 +1,37 @@
+package org.ngrinder.common.util;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.springframework.security.core.context.SecurityContextHolder.getContext;
+
+/**
+ * Spring Security Utility functions.
+ *
+ * @since 3.4.2
+ */
+public class SpringSecurityUtils {
+
+	/**
+	 * Get current user authorities.
+	 */
+	@SuppressWarnings("unchecked")
+	public static Collection<? extends GrantedAuthority> getCurrentAuthorities() {
+		return (getContext().getAuthentication() != null) ? getContext().getAuthentication().getAuthorities() : Collections.EMPTY_LIST;
+	}
+
+	/**
+	 * Check current user has specific authority.
+	 */
+	public static boolean containsAuthority(Collection<? extends GrantedAuthority> authorities, String requiredAuth) {
+		for (GrantedAuthority grantedAuthority : authorities) {
+			if (grantedAuthority.getAuthority().equals(requiredAuth)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/ngrinder-controller/src/main/webapp/WEB-INF/ftl/agent/list.ftl
+++ b/ngrinder-controller/src/main/webapp/WEB-INF/ftl/agent/list.ftl
@@ -13,6 +13,8 @@
 		<legend class="header"> <@spring.message "agent.list.title"/> </legend>
 	</fieldSet>
 	<#include "region_selector.ftl">
+
+	<@security.authorize access="hasRole('A')">
 	<div class="well search-bar">
 		<button class="btn btn-success" id="update_agent_button">
 			<i class="icon-arrow-up"></i> <@spring.message "agent.list.update"/>
@@ -36,11 +38,12 @@
 				</#if>
 			</span>
 		</div>
-
 	</div>
+	</@security.authorize>
 
 	<table class="table table-striped table-bordered ellipsis" id="agent_table">
 		<colgroup>
+		<@security.authorize access="hasRole('A')">
 			<col width="30">
 			<col width="80">
 			<col width="130">
@@ -49,25 +52,41 @@
 			<col width="100">
 			<col width="150">
 			<col width="160">
+		</@security.authorize>
+		<@security.authorize access="hasAnyRole('S', 'U')">
+			<col width="90">
+			<col width="170">
+			<col width="100">
+			<col width="*">
+			<col width="150">
+			<col width="190">
+		</@security.authorize>
 		</colgroup>
 		<thead>
 		<tr>
+		<@security.authorize access="hasRole('A')">
 			<th class="no-click"><input type="checkbox" class="checkbox" value=""></th>
+		</@security.authorize>
 			<th><@spring.message "agent.list.state"/></th>
 			<th><@spring.message "agent.list.IPAndDns"/></th>
 			<th class="no-click"><@spring.message "agent.list.port"/></th>
 			<th class="ellipsis"><@spring.message "agent.list.name"/></th>
 			<th><@spring.message "agent.list.version"/></th>
 			<th><@spring.message "agent.list.region"/></th>
+		<@security.authorize access="hasRole('A')">
 			<th class="no-click"><@spring.message "agent.list.approved"/></th>
+		</@security.authorize>
 		</tr>
 		</thead>
 		<tbody>
-		<@list list_items=agents others="table_list" colspan="8"; agent>
+		<#if isAdmin??><#assign column=8/><#else><#assign column=6/></#if>
+		<@list list_items=agents others="table_list" colspan="${column}"; agent>
 		<tr>
-			<td class="center">
-				<input type="checkbox" class="agent-state checkbox" status="${(agent.state)!}" value="${agent.id}">
-			</td>
+			<@security.authorize access="hasRole('A')">
+				<td class="center">
+					<input type="checkbox" class="agent-state checkbox" status="${(agent.state)!}" value="${agent.id}">
+				</td>
+			</@security.authorize>
 			<td class="center" id="row_${agent.id}">
 				<div class="ball" id="ball_${agent.id}"
 					 data-html="true"
@@ -77,13 +96,19 @@
 			</td>
 			<td>
 				<div class="ellipsis" title="${agent.ip}">
-					<a href="${req.getContextPath()}/agent/${agent.id}" target="_self" value="${agent.ip}">${agent.ip}</a>
+					<@security.authorize access="hasRole('A')">
+						<a href="${req.getContextPath()}/agent/${agent.id}" target="_self" value="${agent.ip}">${agent.ip}</a>
+					</@security.authorize>
+					<@security.authorize access="hasAnyRole('S', 'U')">
+						<span>${agent.ip}</span>
+					</@security.authorize>
 				</div>
 			</td>
 			<td id="port_${agent.id}">${(agent.port)!}</td>
 			<td class="ellipsis agent-name" title="${(agent.hostName)!}">${(agent.hostName)!}</td>
 			<td class="ellipsis"><#if agent.version?has_content>${agent.version}<#else>Prior to 3.3</#if></td>
 			<td class="ellipsis" <#if (agent.region)??>title="${(agent.region)!}"</#if> >${(agent.region)!}</td>
+			<@security.authorize access="hasRole('A')">
 			<td>
 				<div class="btn-group" data-toggle="buttons-radio">
 					<button type="button"
@@ -98,6 +123,7 @@
 					</button>
 				</div>
 			</td>
+			</@security.authorize>
 		</tr>
 		</@list>
 		</tbody>
@@ -117,9 +143,17 @@
 			"bInfo": false,
 			"iDisplayLength": 10,
 			"aaSorting": [
-				[2, "asc"]
+				<#if isAdmin??>
+					[2, "asc"]
+				<#else>
+					[1, "asc"]
+				</#if>
 			],
-			"aoColumns": [null, null, {"asSorting": []}, {"asSorting": []}, null, null, null, {"asSorting": []}],
+			<#if isAdmin??>
+				"aoColumns": [null, null, {"asSorting": []}, {"asSorting": []}, null, null, null, {"asSorting": []}],
+			<#else>
+				"aoColumns": [null, {"asSorting": []}, {"asSorting": []}, null, null, null],
+			</#if>
 			"sPaginationType": "bootstrap",
 			"oLanguage": {
 				"oPaginate": {

--- a/ngrinder-controller/src/main/webapp/WEB-INF/ftl/common/navigator.ftl
+++ b/ngrinder-controller/src/main/webapp/WEB-INF/ftl/common/navigator.ftl
@@ -100,14 +100,16 @@
 						<li>
 							<a href="https://github.com/naver/ngrinder/wiki/nGrinder-Recorder-Guide" target="_blank"><@spring.message "navigator.dropDown.downloadRecorder"/></a>
 						</li>
+						<li class="divider"></li>
 						<@security.authorize access="hasRole('A')">
-							<li class="divider"></li>
 							<li>
 								<a href="${req.getContextPath()}/user/"><@spring.message "navigator.dropDown.userManagement"/></a>
 							</li>
+						</@security.authorize>
 							<li>
 								<a href="${req.getContextPath()}/agent/"><@spring.message "navigator.dropDown.agentManagement"/></a>
 							</li>
+						<@security.authorize access="hasRole('A')">
 							<#if clustered == false>
 								<li>
 									<a href="${req.getContextPath()}/operation/log"><@spring.message "navigator.dropDown.logMonitoring"/></a>

--- a/ngrinder-controller/src/test/java/org/ngrinder/agent/controller/AgentManagerControllerTest.java
+++ b/ngrinder-controller/src/test/java/org/ngrinder/agent/controller/AgentManagerControllerTest.java
@@ -24,6 +24,7 @@ import org.ngrinder.agent.repository.AgentManagerRepository;
 import org.ngrinder.agent.service.AgentManagerService;
 import org.ngrinder.infra.config.Config;
 import org.ngrinder.model.AgentInfo;
+import org.ngrinder.user.service.UserContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -54,6 +55,9 @@ public class AgentManagerControllerTest extends AbstractNGrinderTransactionalTes
 	@Autowired
 	private Config config;
 
+	@Autowired
+	private UserContext userContext;
+
 	@Before
 	public void setMockRequest() {
 		MockHttpServletRequest req = new MockHttpServletRequest();
@@ -72,7 +76,7 @@ public class AgentManagerControllerTest extends AbstractNGrinderTransactionalTes
 	public void testGetAgentList() {
 
 		ModelMap model = new ModelMap();
-		agentController.getAll("", model);
+		agentController.getAll(userContext.getCurrentUser(), "", model);
 
 		// create a temp download dir and file for this function
 		File directory = config.getHome().getDownloadDirectory();
@@ -93,7 +97,7 @@ public class AgentManagerControllerTest extends AbstractNGrinderTransactionalTes
 		}
 
 		model.clear();
-		agentController.getAll("", model);
+		agentController.getAll(userContext.getCurrentUser(), "", model);
 		Collection<AgentInfo> agents = (Collection<AgentInfo>) model.get("agents");
 	}
 


### PR DESCRIPTION
#304 

Users can view the list of public and User's agents from the agent management menu.
(This menu previously only supported for admin.)

![image](https://user-images.githubusercontent.com/14273601/44200833-94426600-a182-11e8-82b3-430ad3b819d4.png)

They can only view the following information about the agents.

![image](https://user-images.githubusercontent.com/14273601/44202895-42044380-a188-11e8-9e34-5527ef9a96da.png)

