### PR TITLE
Pass working directory to test process to avoid wrong ngrinder home path on symbolic lynk

### DIFF
--- a/ngrinder-core/src/main/java/net/grinder/engine/agent/PropertyBuilder.java
+++ b/ngrinder-core/src/main/java/net/grinder/engine/agent/PropertyBuilder.java
@@ -176,6 +176,7 @@ public class PropertyBuilder {
 		jvmArguments = addParam(jvmArguments, properties.getProperty("grinder.param", ""));
 		jvmArguments = addPythonPathJvmArgument(jvmArguments);
 		jvmArguments = addCustomDns(jvmArguments);
+		jvmArguments = addUserDir(jvmArguments);
 		if (server) {
 			jvmArguments = addServerMode(jvmArguments);
 		}
@@ -365,6 +366,11 @@ public class PropertyBuilder {
 		if (enableLocalDNS) {
 			jvmArguments.append(" -Dsun.net.spi.nameservice.provider.1=dns,LocalManagedDns ");
 		}
+		return jvmArguments;
+	}
+
+	private StringBuilder addUserDir(StringBuilder jvmArguments) {
+		jvmArguments.append(" -Duser.dir=" + baseDirectory.getFile().getPath() + " ");
 		return jvmArguments;
 	}
 


### PR DESCRIPTION
Java `System.getProperty ("user.dir")` return the link value when current execution location is a symbolic link. so `workDirectory` value in security manager is different from what i expected.

This commit passes ```ngrinder.base.path``` to test process as a system property. So the path resolution  in security manager can handle the file access well.

