### PR TITLE
Provide the way to turn off security mode in agent config.

### DIFF
--- a/ngrinder-core/src/main/java/net/grinder/engine/agent/AgentImplementationEx.java
+++ b/ngrinder-core/src/main/java/net/grinder/engine/agent/AgentImplementationEx.java
@@ -366,10 +366,13 @@ public class AgentImplementationEx implements Agent, AgentConstants {
 		return newProperties;
 	}
 
+	private boolean isSecurityEnabled(GrinderProperties properties) {
+		return m_agentConfig.isSecurityEnabled() && properties.getBoolean(GRINDER_PROP_SECURITY, false);
+	}
+
 	private String buildTestRunProperties(ScriptLocation script, AbstractLanguageHandler handler, Properties systemProperty,
 	                                      GrinderProperties properties) {
-		PropertyBuilder builder = new PropertyBuilder(properties, script.getDirectory(), properties.getBoolean(
-				GRINDER_PROP_SECURITY, false), properties.getProperty(GRINDER_PROP_SECURITY_LEVEL, GRINDER_SECURITY_LEVEL_NORMAL), properties.getProperty(GRINDER_PROP_ETC_HOSTS),
+		PropertyBuilder builder = new PropertyBuilder(properties, script.getDirectory(), isSecurityEnabled(properties), properties.getProperty(GRINDER_PROP_SECURITY_LEVEL, GRINDER_SECURITY_LEVEL_NORMAL), properties.getProperty(GRINDER_PROP_ETC_HOSTS),
 				NetworkUtils.getLocalHostName(), m_agentConfig.getAgentProperties().getPropertyBoolean(PROP_AGENT_SERVER_MODE),
 				m_agentConfig.getAgentProperties().getPropertyBoolean(PROP_AGENT_LIMIT_XMX),
 				m_agentConfig.getAgentProperties().getPropertyBoolean(PROP_AGENT_ENABLE_LOCAL_DNS),

--- a/ngrinder-core/src/main/java/org/ngrinder/common/constants/AgentConstants.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/common/constants/AgentConstants.java
@@ -30,5 +30,6 @@ public interface AgentConstants {
 	public static final String PROP_AGENT_REGION = "agent.region";
 	public static final String PROP_AGENT_SERVER_MODE = "agent.server_mode";
 	public static final String PROP_AGENT_ENABLE_LOCAL_DNS = "agent.enable_local_dns";
+	public static final String PROP_AGENT_ENABLE_SECURITY = "agent.enable_security";
 
 }

--- a/ngrinder-core/src/main/java/org/ngrinder/infra/AgentConfig.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/infra/AgentConfig.java
@@ -338,6 +338,10 @@ public class AgentConfig implements AgentConstants, MonitorConstants, CommonCons
 		return getAgentProperties().getProperty(PROP_AGENT_HOST_ID, NetworkUtils.DEFAULT_LOCAL_HOST_NAME);
 	}
 
+	public boolean isSecurityEnabled() {
+		return getAgentProperties().getPropertyBoolean(PROP_AGENT_ENABLE_SECURITY);
+	}
+
 	public boolean isServerMode() {
 		return getAgentProperties().getPropertyBoolean(PROP_AGENT_SERVER_MODE);
 	}

--- a/ngrinder-core/src/main/resources/agent-properties.map
+++ b/ngrinder-core/src/main/resources/agent-properties.map
@@ -10,3 +10,4 @@ agent.java_opt,,agent.javaopt
 agent.keep_logs,false,
 agent.update_always,false,
 agent.enable_local_dns,true,
+agent.enable_security,true,

--- a/ngrinder-core/src/main/resources/agent.conf
+++ b/ngrinder-core/src/main/resources/agent.conf
@@ -14,3 +14,7 @@ common.start_mode=agent
 
 # some jvm is not compatible with DNSJava. If so, set this false.
 #agent.enable_local_dns=false
+
+# default value is true.
+# when `agent.enable_security=false` the agent always runs in insecure mode.
+#agent.enable_security=true


### PR DESCRIPTION
Add `agent.enable_security` configuration to `agent_conf`.

It is used to operate regardless of the `controller.security` configuration of the controller.

when `agent.enable_security=false` the agent always runs in unsecurity mode.

default value is true.(It depends on controller security configuration.)