### PR TITLE
Make the target host field mandatory only in normal security level

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/common/constant/WebConstants.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/common/constant/WebConstants.java
@@ -47,5 +47,6 @@ public interface WebConstants {
 	public static final String PARAM_MAX_RUN_HOUR = "maxRunHour";
 	public static final String PARAM_SAFE_FILE_DISTRIBUTION = "safeFileDistribution";
 
-	public static final String PARAM_SECURITY_MODE = "securityMode";
+	public static final String PARAM_SECURITY_LEVEL = "securityLevel";
+
 }

--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/controller/PerfTestController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/controller/PerfTestController.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.lang.mutable.MutableInt;
 import org.ngrinder.agent.service.AgentManagerService;
 import org.ngrinder.common.constant.ControllerConstants;
+import org.ngrinder.common.constants.GrinderConstants;
 import org.ngrinder.common.controller.BaseController;
 import org.ngrinder.common.controller.RestAPI;
 import org.ngrinder.common.util.DateUtils;
@@ -250,7 +251,9 @@ public class PerfTestController extends BaseController {
 		model.addAttribute(PARAM_AVAILABLE_RAMP_UP_TYPE, RampUp.values());
 		model.addAttribute(PARAM_MAX_VUSER_PER_AGENT, agentManager.getMaxVuserPerAgent());
 		model.addAttribute(PARAM_MAX_RUN_COUNT, agentManager.getMaxRunCount());
-		model.addAttribute(PARAM_SECURITY_MODE, getConfig().isSecurityEnabled());
+		if (getConfig().isSecurityEnabled()) {
+			model.addAttribute(PARAM_SECURITY_LEVEL, getConfig().getSecurityLevel());
+		}
 		model.addAttribute(PARAM_MAX_RUN_HOUR, agentManager.getMaxRunHour());
 		model.addAttribute(PARAM_SAFE_FILE_DISTRIBUTION,
 				getConfig().getControllerProperties().getPropertyBoolean(ControllerConstants.PROP_CONTROLLER_SAFE_DIST));
@@ -368,7 +371,7 @@ public class PerfTestController extends BaseController {
 
 		checkArgument(newOne.getVuserPerAgent() <= agentManager.getMaxVuserPerAgent(),
 				"vuserPerAgent should be equal to or less than %s", agentManager.getMaxVuserPerAgent());
-		if (getConfig().isSecurityEnabled()) {
+		if (getConfig().isSecurityEnabled() && GrinderConstants.GRINDER_SECURITY_LEVEL_NORMAL.equals(getConfig().getSecurityLevel())) {
 			checkArgument(StringUtils.isNotEmpty(newOne.getTargetHosts()),
 					"targetHosts should be provided when security mode is enabled");
 		}

--- a/ngrinder-controller/src/main/webapp/WEB-INF/ftl/perftest/detail.ftl
+++ b/ngrinder-controller/src/main/webapp/WEB-INF/ftl/perftest/detail.ftl
@@ -553,7 +553,7 @@ function addValidation() {
 				digits: true,
 				min: 0
 			},
-			<#if securityMode?? && securityMode == true>
+			<#if securityLevel?? && securityLevel == "normal">
 			targetHosts: {
 				required: true
 			},


### PR DESCRIPTION
When security mode is enabled but its level is light, the target host field in perftest config is not mandatory.
