### PR TITLE
Make gtest only instrument method in ngrinder context

### DIFF
--- a/ngrinder-controller/src/main/resources/script_template/groovy_maven/pom.xml
+++ b/ngrinder-controller/src/main/resources/script_template/groovy_maven/pom.xml
@@ -6,7 +6,7 @@
 	<version>0.0.1</version>
 
 	<properties>
-		<ngrinder.version>3.4</ngrinder.version>
+		<ngrinder.version>3.4.2-SNAPSHOT</ngrinder.version>
 		<maven.compiler.source>1.7</maven.compiler.source>
 		<maven.compiler.target>1.7</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/ngrinder-core/src/main/java/net/grinder/engine/agent/LocalScriptTestDriveService.java
+++ b/ngrinder-core/src/main/java/net/grinder/engine/agent/LocalScriptTestDriveService.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -9,7 +9,7 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License. 
+ * limitations under the License.
  */
 package net.grinder.engine.agent;
 

--- a/ngrinder-core/src/main/java/net/grinder/engine/agent/PropertyBuilder.java
+++ b/ngrinder-core/src/main/java/net/grinder/engine/agent/PropertyBuilder.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -9,7 +9,7 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License. 
+ * limitations under the License.
  */
 package net.grinder.engine.agent;
 
@@ -177,6 +177,8 @@ public class PropertyBuilder {
 		jvmArguments = addPythonPathJvmArgument(jvmArguments);
 		jvmArguments = addCustomDns(jvmArguments);
 		jvmArguments = addUserDir(jvmArguments);
+		jvmArguments = addContext(jvmArguments);
+
 		if (server) {
 			jvmArguments = addServerMode(jvmArguments);
 		}
@@ -186,18 +188,22 @@ public class PropertyBuilder {
 		return jvmArguments.toString();
 	}
 
-	private StringBuilder addParam(StringBuilder jvmArguments, String param) {
+	protected StringBuilder addContext(StringBuilder jvmArguments) {
+		return jvmArguments.append( " -Dngrinder.context=agent ");
+	}
+
+	protected StringBuilder addParam(StringBuilder jvmArguments, String param) {
 		if (StringUtils.isEmpty(param)) {
 			return jvmArguments;
 		}
 		return jvmArguments.append(" -Dparam=").append(param).append(" ");
 	}
 
-	private StringBuilder addAdditionalJavaOpt(StringBuilder jvmArguments) {
+	protected StringBuilder addAdditionalJavaOpt(StringBuilder jvmArguments) {
 		return jvmArguments.append(" ").append(additionalJavaOpt).append(" ");
 	}
 
-	private StringBuilder addNativeLibraryPath(StringBuilder jvmArguments) {
+	protected StringBuilder addNativeLibraryPath(StringBuilder jvmArguments) {
 		return jvmArguments.append(" -Djna.library.path=").append(new File(baseDirectory.getFile(), "/lib"))
 				.append(" ");
 	}

--- a/ngrinder-core/src/main/java/net/grinder/engine/agent/ValidationPropertyBuilder.java
+++ b/ngrinder-core/src/main/java/net/grinder/engine/agent/ValidationPropertyBuilder.java
@@ -9,7 +9,7 @@ public class ValidationPropertyBuilder extends PropertyBuilder {
 	}
 
 	@Override
-	public String buildJVMArgumentWithoutMemory() {
-		return super.buildJVMArgumentWithoutMemory() + " -Dngrinder.context=controller ";
+	protected StringBuilder addContext(StringBuilder jvmArguments) {
+		return jvmArguments.append( " -Dngrinder.context=controller ");
 	}
 }

--- a/ngrinder-groovy/src/main/java/net/grinder/script/GTest.java
+++ b/ngrinder-groovy/src/main/java/net/grinder/script/GTest.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -9,9 +9,11 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License. 
+ * limitations under the License.
  */
 package net.grinder.script;
+
+import org.apache.commons.lang.StringUtils;
 
 import java.lang.reflect.Method;
 
@@ -33,6 +35,7 @@ public class GTest extends Test {
 	 */
 	private static final long serialVersionUID = 8370116882992463352L;
 
+	private String context;
 	/**
 	 * Constructor.
 	 *
@@ -41,6 +44,7 @@ public class GTest extends Test {
 	 */
 	public GTest(int number, String description) {
 		super(number, description);
+		context = System.getProperty("ngrinder.context");
 	}
 
 	/**
@@ -54,7 +58,9 @@ public class GTest extends Test {
 	 * @since 3.2.1
 	 */
 	public final void record(Object target, String methodName) throws NonInstrumentableTypeException {
-		record(target, new MethodNameFilter(methodName));
+		if (StringUtils.isNotEmpty(context)) {
+			record(target, new MethodNameFilter(methodName));
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fix for #334 
This PR introduces ngrinder.context system property to determine the current context (junit or ngrinder)
Only when ngrinder.context property is given, gtest instruments the code so that the debugging  will be enabled.