### PR TITLE
Prepare 3.5.0

### DIFF
--- a/ngrinder-controller/pom.xml
+++ b/ngrinder-controller/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.ngrinder</groupId>
 		<artifactId>ngrinder</artifactId>
-		<version>3.4.2</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>ngrinder-controller</artifactId>
 	<name>ngrinder-controller</name>

--- a/ngrinder-controller/src/main/resources/script_template/groovy_maven/pom.xml
+++ b/ngrinder-controller/src/main/resources/script_template/groovy_maven/pom.xml
@@ -6,7 +6,7 @@
 	<version>0.0.1</version>
 
 	<properties>
-		<ngrinder.version>3.4.2</ngrinder.version>
+		<ngrinder.version>3.5.0-SNAPSHOT</ngrinder.version>
 		<maven.compiler.source>1.7</maven.compiler.source>
 		<maven.compiler.target>1.7</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/ngrinder-core/pom.xml
+++ b/ngrinder-core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>ngrinder</artifactId>
 		<groupId>org.ngrinder</groupId>
-		<version>3.4.2</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>ngrinder-core</artifactId>
 	<name>ngrinder-core</name>

--- a/ngrinder-groovy/pom.xml
+++ b/ngrinder-groovy/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.ngrinder</groupId>
 		<artifactId>ngrinder</artifactId>
-		<version>3.4.2</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>ngrinder-groovy</artifactId>
 	<name>ngrinder-groovy</name>

--- a/ngrinder-runtime/pom.xml
+++ b/ngrinder-runtime/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.ngrinder</groupId>
 		<artifactId>ngrinder</artifactId>
-		<version>3.4.2</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>ngrinder-runtime</artifactId>
 	<name>ngrinder-runtime</name>

--- a/ngrinder-sh/pom.xml
+++ b/ngrinder-sh/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>org.ngrinder</groupId>
 	<artifactId>ngrinder-sh</artifactId>
 	<name>ngrinder-sh</name>
-	<version>3.4.2</version>
+	<version>3.5.0-SNAPSHOT</version>
 
 	<packaging>jar</packaging>
 	<build>

--- a/ngrinder-starter/pom.xml
+++ b/ngrinder-starter/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.ngrinder</groupId>
 		<artifactId>ngrinder</artifactId>
-		<version>3.4.2</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>ngrinder-starter</artifactId>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.ngrinder</groupId>
 	<artifactId>ngrinder</artifactId>
-	<version>3.4.2</version>
+	<version>3.5.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>ngrinder</name>
 	<modules>


### PR DESCRIPTION
Since nGrinder 3.4.2 has been released, update version as 3.5.0-SNAPSHOT.
