### PR TITLE
Add defence code for NPE when get ready agent count

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/agent/service/AgentManagerService.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/agent/service/AgentManagerService.java
@@ -543,7 +543,7 @@ public class AgentManagerService extends AbstractAgentManagerService {
 				continue;
 			}
 			String fullRegion = agentInfo.getRegion();
-			if (fullRegion.equals(targetRegion) || fullRegion.equals(myOwnAgent)) {
+			if (StringUtils.equals(fullRegion, targetRegion) || StringUtils.equals(fullRegion, myOwnAgent)) {
 				readyAgentCnt++;
 			}
 		}


### PR DESCRIPTION
When agent configuration `region` is empty such as `region=` NPE occurs in `getReadyAgentCount`.

Therefore, use `StringUtils.equals` to compare strings.