### PR TITLE
Add character encoding option in mysql connection string

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/config/Database.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/config/Database.java
@@ -34,7 +34,7 @@ public enum Database {
 	/**
 	 * MYSQL.
 	 */
-	mysql(com.mysql.jdbc.Driver.class, MYSQLExDialect.class, "jdbc:mysql://%s%s") {
+	mysql(com.mysql.jdbc.Driver.class, MYSQLExDialect.class, "jdbc:mysql://%s?characterEncoding=utf8&%s") {
 		@Override
 		protected void setupVariants(BasicDataSource dataSource, PropertiesWrapper databaseProperties) {
 			dataSource.setUrl(String.format(getUrlTemplate(), databaseProperties.getProperty(DatabaseConfig.PROP_DATABASE_URL),

--- a/ngrinder-controller/src/main/resources/ngrinder_home_template/database.conf
+++ b/ngrinder-controller/src/main/resources/ngrinder_home_template/database.conf
@@ -7,7 +7,7 @@ database.type=H2
 
 # if you apply additional options for mysql database enable this.
 # this is added after the 'database.url' config.
-#database.url_option=?characterEncoding=utf8
+#database.url_option=
 
 # for H2 remote connection, You should configure like followings.
 # You can see how to run the H2 DB server by yourself in http://www.h2database.com/html/tutorial.html#using_server


### PR DESCRIPTION
When user selects mysql as their database, Automatically set character encoding to utf-8.