### PR TITLE
Convert ehcache to hazelcast.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ subprojects {
     springboot_version = "1.4.1.RELEASE"
     svnkit_version = "1.8.3-scm1"
     hibernate_version = "5.0.11.Final"
+    hazelcast_version = "3.11.1"
   }
 
   repositories {

--- a/ngrinder-controller/build.gradle
+++ b/ngrinder-controller/build.gradle
@@ -57,6 +57,8 @@ dependencies {
         exclude (module: "slf4j-log4j12")
     }
     compile (group: "org.reflections", name: "reflections", version: "0.9.9")
+    compile (group: "com.hazelcast", name: "hazelcast", version: hazelcast_version)
+    compile (group: "com.hazelcast", name: "hazelcast-spring", version: hazelcast_version)
 
     providedRuntime (group: 'org.springframework.boot', name: 'spring-boot-starter-tomcat', version: springboot_version)
 

--- a/ngrinder-controller/src/main/java/org/ngrinder/agent/controller/AgentManagerController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/agent/controller/AgentManagerController.java
@@ -167,17 +167,17 @@ public class AgentManagerController extends BaseController {
 	/**
 	 * Get the current performance of the given agent.
 	 *
-	 * @param id   agent id
-	 * @param ip   agent ip
+	 * @param ip agent ip
 	 * @param name agent name
+	 * @param region agent region
+	 *
 	 * @return json message
 	 */
 
 	@PreAuthorize("hasAnyRole('A')")
-	@RequestMapping("/api/{id}/state")
-	public HttpEntity<String> getState(@PathVariable Long id, @RequestParam String ip, @RequestParam String name) {
-		agentManagerService.requestShareAgentSystemDataModel(id);
-		return toJsonHttpEntity(agentManagerService.getSystemDataModel(ip, name));
+	@RequestMapping("/api/state")
+	public HttpEntity<String> getState(@RequestParam String ip, @RequestParam String name, @RequestParam String region) {
+		return toJsonHttpEntity(agentManagerService.getSystemDataModel(ip, name, region));
 	}
 
 	/**

--- a/ngrinder-controller/src/main/java/org/ngrinder/agent/model/ClusteredAgentRequest.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/agent/model/ClusteredAgentRequest.java
@@ -18,6 +18,8 @@ import org.ngrinder.agent.service.ClusteredAgentManagerService;
 
 import java.io.Serializable;
 
+import static org.ngrinder.common.util.NoOp.noOp;
+
 /**
  * Agent control request b/w controllers in the clustered nGrinder installation.
  *
@@ -53,6 +55,7 @@ public class ClusteredAgentRequest implements Serializable {
 			@Override
 			public void process(ClusteredAgentManagerService agentManagerService,
 			                    AgentControllerIdentityImplementation agentIdentity) {
+				noOp();
 			}
 
 		},
@@ -61,13 +64,6 @@ public class ClusteredAgentRequest implements Serializable {
 			public void process(ClusteredAgentManagerService agentManagerService,
 								AgentControllerIdentityImplementation agentIdentity) {
 				agentManagerService.updateAgent(agentIdentity);
-			}
-		},
-		SHARE_AGENT_SYSTEM_DATA_MODEL {
-			@Override
-			public void process(ClusteredAgentManagerService agentManagerService,
-								AgentControllerIdentityImplementation agentIdentity) {
-				agentManagerService.addAgentMonitoringTarget(agentIdentity);
 			}
 		};
 

--- a/ngrinder-controller/src/main/java/org/ngrinder/agent/service/AgentManagerService.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/agent/service/AgentManagerService.java
@@ -440,7 +440,7 @@ public class AgentManagerService extends AbstractAgentManagerService {
 	 * (java.lang.String, java.lang.String)
 	 */
 	@Override
-	public SystemDataModel getSystemDataModel(String ip, String name) {
+	public SystemDataModel getSystemDataModel(String ip, String name, String region) {
 		AgentControllerIdentityImplementation agentIdentity = getAgentIdentityByIpAndName(ip, name);
 		return agentIdentity != null ? getAgentManager().getSystemDataModel(agentIdentity) : new SystemDataModel();
 	}
@@ -531,7 +531,7 @@ public class AgentManagerService extends AbstractAgentManagerService {
 	 * Ready agent state count return
 	 *
 	 * @param user The login user
-	 * @param String targetRegion The name of target region
+	 * @param targetRegion targetRegion The name of target region
 	 * @return ready Agent count
 	 */
 	@Override

--- a/ngrinder-controller/src/main/java/org/ngrinder/agent/service/LocalAgentService.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/agent/service/LocalAgentService.java
@@ -29,6 +29,7 @@ import javax.annotation.PostConstruct;
 import java.util.List;
 
 import static org.ngrinder.agent.repository.AgentManagerSpecification.startWithRegion;
+import static org.ngrinder.common.constant.CacheConstants.CACHE_LOCAL_AGENTS;
 
 @Component
 public class LocalAgentService {
@@ -50,7 +51,7 @@ public class LocalAgentService {
 		region = config.getRegion();
 	}
 
-	@Cacheable("local_agents")
+	@Cacheable(CACHE_LOCAL_AGENTS)
 	public List<AgentInfo> getLocalAgents() {
 		LOGGER.debug("Local Cache is Updated.");
 		if (clustered) {
@@ -86,7 +87,7 @@ public class LocalAgentService {
 		runnable.run();
 	}
 
-	@CacheEvict("local_agents")
+	@CacheEvict(CACHE_LOCAL_AGENTS)
 	public void expireCache() {
 
 	}

--- a/ngrinder-controller/src/main/java/org/ngrinder/common/constant/CacheConstants.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/common/constant/CacheConstants.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ngrinder.common.constant;
+
+/**
+ * Cache related Constants.
+ *
+ * @since 3.5.0
+ */
+public interface CacheConstants {
+	String CACHE_SAMPLING = "sampling";
+	String CACHE_MONITORING = "monitoring";
+
+	String CACHE_USERS = "users";
+	String CACHE_FILE_ENTRIES = "file_entries";
+	String CACHE_RIGHT_PANEL_ENTRIES = "right_panel_entries";
+	String CACHE_LEFT_PANEL_ENTRIES = "left_panel_entries";
+	String CACHE_CURRENT_PERFTEST_STATISTICS = "current_perftest_statistics";
+	String CACHE_LOCAL_AGENTS = "local_agents";
+
+	String REGION_ATTR_KEY = "REGION";
+	String REGION_EXECUTOR_SERVICE_NAME = "REGION_EXECUTOR";
+	String AGENT_EXECUTOR_SERVICE_NAME = "AGENT_EXECUTOR";
+
+	int REGION_CACHE_TIME_TO_LIVE_SECONDS = 20;
+}

--- a/ngrinder-controller/src/main/java/org/ngrinder/common/controller/BaseController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/common/controller/BaseController.java
@@ -39,7 +39,6 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.servlet.ModelAndView;
 
 import javax.annotation.PostConstruct;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -171,7 +170,7 @@ public class BaseController implements WebConstants {
 
 
 	@ModelAttribute("visibleRegions")
-	public ArrayList<String> availRegions() {
+	public List<String> availRegions() {
 		return regionService.getAllVisibleRegionNames();
 	}
 

--- a/ngrinder-controller/src/main/java/org/ngrinder/home/service/HomeService.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/home/service/HomeService.java
@@ -31,6 +31,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static org.ngrinder.common.constant.CacheConstants.CACHE_LEFT_PANEL_ENTRIES;
+import static org.ngrinder.common.constant.CacheConstants.CACHE_RIGHT_PANEL_ENTRIES;
 import static org.ngrinder.common.util.TypeConvertUtils.cast;
 
 /**
@@ -52,7 +54,7 @@ public class HomeService {
 	 * @return the list of {@link PanelEntry}
 	 */
 	@SuppressWarnings("unchecked")
-	@Cacheable(value = "left_panel_entries")
+	@Cacheable(value = CACHE_LEFT_PANEL_ENTRIES)
 	public List<PanelEntry> getLeftPanelEntries(String feedURL) {
 		return getPanelEntries(feedURL, PANEL_ENTRY_SIZE, false);
 	}
@@ -64,7 +66,7 @@ public class HomeService {
 	 * @param feedURL rss url message
 	 * @return {@link PanelEntry} list
 	 */
-	@Cacheable(value = "right_panel_entries")
+	@Cacheable(value = CACHE_RIGHT_PANEL_ENTRIES)
 	public List<PanelEntry> getRightPanelEntries(String feedURL) {
 		return getPanelEntries(feedURL, PANEL_ENTRY_SIZE, true);
 	}

--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/config/DynamicCacheConfig.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/config/DynamicCacheConfig.java
@@ -13,35 +13,44 @@
  */
 package org.ngrinder.infra.config;
 
+import com.google.common.cache.CacheBuilder;
+import com.hazelcast.config.*;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ITopic;
+import com.hazelcast.core.MessageListener;
+import com.hazelcast.spring.cache.HazelcastCacheManager;
+import com.hazelcast.spring.context.SpringManagedContext;
 import net.grinder.util.NetworkUtils;
-import net.grinder.util.Pair;
-import net.sf.ehcache.CacheManager;
 import net.sf.ehcache.config.CacheConfiguration;
 import net.sf.ehcache.config.CacheConfiguration.CacheEventListenerFactoryConfiguration;
 import net.sf.ehcache.config.Configuration;
-import net.sf.ehcache.config.ConfigurationFactory;
-import net.sf.ehcache.config.FactoryConfiguration;
-import net.sf.ehcache.distribution.RMICacheManagerPeerListenerFactory;
-import net.sf.ehcache.distribution.RMICacheManagerPeerProviderFactory;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
 import org.ngrinder.common.constant.ClusterConstants;
-import org.ngrinder.common.util.Preconditions;
+import org.ngrinder.common.exception.NGrinderRuntimeException;
+import org.ngrinder.infra.hazelcast.topic.message.TopicEvent;
+import org.ngrinder.infra.hazelcast.topic.subscriber.TopicSubscriber;
 import org.ngrinder.infra.logger.CoreLogger;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cache.ehcache.EhCacheCacheManager;
+import org.springframework.cache.Cache;
+import org.springframework.cache.guava.GuavaCache;
+import org.springframework.cache.support.CompositeCacheManager;
+import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.Bean;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.stereotype.Component;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.net.InetAddress;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.config.MaxSizeConfig.MaxSizePolicy.PER_NODE;
+import static net.grinder.util.NetworkUtils.DEFAULT_LOCAL_HOST_ADDRESS;
+import static org.ngrinder.common.constant.CacheConstants.*;
 import static org.ngrinder.common.util.TypeConvertUtils.cast;
+import static org.ngrinder.infra.config.DynamicCacheConfig.CacheConfigHolder.Mode.DIST;
+import static org.ngrinder.infra.config.DynamicCacheConfig.CacheConfigHolder.Mode.DIST_AND_LOCAL;
+import static org.ngrinder.infra.hazelcast.topic.subscriber.TopicSubscriber.TOPIC_NAME;
 
 /**
  * Dynamic cache configuration. This get the control of EhCache configuration from Spring. Depending
@@ -51,130 +60,194 @@ import static org.ngrinder.common.util.TypeConvertUtils.cast;
  * @author JunHo Yoon
  * @since 3.1
  */
-@SuppressWarnings("SpellCheckingInspection")
-@Component
+@org.springframework.context.annotation.Configuration
 public class DynamicCacheConfig implements ClusterConstants {
 
 	@Autowired
 	private Config config;
 
-	/**
-	 * Create cache manager dynamically according to the configuration.
-	 *
-	 * @return EhCacheCacheManager bean
-	 */
-	@SuppressWarnings("rawtypes")
-	@Bean(name = "cacheManager")
-	public EhCacheCacheManager dynamicCacheManager() {
-		EhCacheCacheManager cacheManager = new EhCacheCacheManager();
-		Configuration cacheManagerConfig;
-		InputStream inputStream = null;
-		try {
-			if (!isClustered()) {
-				inputStream = new ClassPathResource("ehcache.xml").getInputStream();
-				cacheManagerConfig = ConfigurationFactory.parseConfiguration(inputStream);
-			} else {
-				CoreLogger.LOGGER.info("In cluster mode.");
-				inputStream = new ClassPathResource("ehcache-dist.xml").getInputStream();
-				cacheManagerConfig = ConfigurationFactory.parseConfiguration(inputStream);
-				Pair<FactoryConfiguration, NetworkUtils.IPPortPair> result =
-						createRMICacheManagerPeerProviderFactory(cacheManagerConfig);
-				cacheManagerConfig.addCacheManagerPeerProviderFactory(result.getFirst());
-				cacheManagerConfig.addCacheManagerPeerListenerFactory(
-						createPearListenerFactory(result.getSecond().getIP(), result.getSecond().getPort()));
-			}
-			cacheManagerConfig.setName(getCacheName());
-			CacheManager mgr = CacheManager.create(cacheManagerConfig);
-			cacheManager.setCacheManager(mgr);
+	private final int DAY = 24 * 60 * 60;
+	private final int HOUR = 60 * 60;
+	private final int MIN = 60;
 
-		} catch (IOException e) {
-			CoreLogger.LOGGER.error("Error while setting up cache", e);
-		} finally {
-			IOUtils.closeQuietly(inputStream);
+	@Bean
+	public org.springframework.cache.CacheManager cacheManager() {
+		return new CompositeCacheManager(getLocalCacheManager(), getDistCacheManager());
+	}
+
+	private SimpleCacheManager getLocalCacheManager() {
+		SimpleCacheManager cacheManager = new SimpleCacheManager();
+		List<Cache> caches = new ArrayList<>();
+		for (Map.Entry<String, CacheBuilder<Object, Object>> each : cacheConfigMap().getGuavaCacheConfig().entrySet()) {
+			caches.add(new GuavaCache(each.getKey(), each.getValue().build()));
 		}
+		cacheManager.setCaches(caches);
+		cacheManager.initializeCaches();
 		return cacheManager;
+	}
+
+	private HazelcastCacheManager getDistCacheManager() {
+		return new HazelcastCacheManager(embeddedHazelcast());
+	}
+
+	@Bean
+	public SpringManagedContext managedContext() {
+		return new SpringManagedContext();
+	}
+
+	@Bean
+	public HazelcastInstance embeddedHazelcast() {
+		com.hazelcast.config.Config hazelcastConfig = new com.hazelcast.config.Config();
+		hazelcastConfig.setManagedContext(managedContext());
+		hazelcastConfig.getMemberAttributeConfig().setAttributes(getClusterMemberAttributes());
+		hazelcastConfig.setMapConfigs(cacheConfigMap().getHazelcastCacheConfigs());
+		hazelcastConfig.addExecutorConfig(getExecutorConfig(REGION_EXECUTOR_SERVICE_NAME));
+		hazelcastConfig.addExecutorConfig(getExecutorConfig(AGENT_EXECUTOR_SERVICE_NAME));
+		hazelcastConfig.addTopicConfig(getTopicConfig());
+		NetworkConfig networkConfig = hazelcastConfig.getNetworkConfig();
+		networkConfig.setPort(getClusterPort());
+
+		if (getClusterURIs() != null && getClusterURIs().length > 0) {
+			JoinConfig join = networkConfig.getJoin();
+			join.getAwsConfig().setEnabled(false);
+			join.getMulticastConfig().setEnabled(false);
+			TcpIpConfig tcpIpConfig = join.getTcpIpConfig();
+			tcpIpConfig.setEnabled(true);
+			tcpIpConfig.setMembers(Arrays.asList(getClusterURIs()));
+			networkConfig.setPublicAddress(getMyPublicAddress(Arrays.asList(getClusterURIs())));
+		} else {
+			JoinConfig join = networkConfig.getJoin();
+			join.getAwsConfig().setEnabled(false);
+			join.getTcpIpConfig().setEnabled(false);
+			join.getMulticastConfig().setEnabled(true);
+		}
+
+		HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance(hazelcastConfig);
+		ITopic<TopicEvent> topic = hazelcastInstance.getTopic(TOPIC_NAME);
+		topic.addMessageListener(getTopicSubscriber());
+		return hazelcastInstance;
+	}
+
+	private ExecutorConfig getExecutorConfig(String regionExecutorService) {
+		ExecutorConfig config = new ExecutorConfig();
+		config.setName(regionExecutorService);
+		return config;
+	}
+
+	private TopicConfig getTopicConfig() {
+		TopicConfig topicConfig = new TopicConfig();
+		topicConfig.setGlobalOrderingEnabled(true);
+		topicConfig.setStatisticsEnabled(true);
+		topicConfig.setName(TOPIC_NAME);
+		return topicConfig;
+	}
+
+	private Map<String, Object> getClusterMemberAttributes() {
+		Map<String, Object> attributes = new HashMap<>();
+		attributes.put(REGION_ATTR_KEY, config.getRegion());
+		return attributes;
+	}
+
+	private String getMyPublicAddress(List<String> ips) {
+		try {
+			Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+			while (interfaces.hasMoreElements()) {
+				NetworkInterface iface = interfaces.nextElement();
+				if (iface.isLoopback() || !iface.isUp())
+					continue;
+
+				Enumeration<InetAddress> addresses = iface.getInetAddresses();
+				while (addresses.hasMoreElements()) {
+					InetAddress addr = addresses.nextElement();
+					String hostAddress = addr.getHostAddress();
+					if (ips.contains(hostAddress)) {
+						return hostAddress;
+					}
+				}
+			}
+		} catch (SocketException e) {
+			throw new NGrinderRuntimeException("error while resolving current ip", e);
+		}
+		throw new NGrinderRuntimeException("the ip address set doesn't contain current ips");
+	}
+
+	@Bean
+	public MessageListener<TopicEvent> getTopicSubscriber() {
+		return new TopicSubscriber();
+	}
+
+	@SuppressWarnings("PointlessArithmeticExpression")
+	@Bean
+	public CacheConfigHolder cacheConfigMap() {
+		CacheConfigHolder cm = new CacheConfigHolder();
+		cm.addDistCache(CACHE_SAMPLING, 15, 15 , DIST , 0 , 0);
+		cm.addDistCache(CACHE_MONITORING, 15, 15, DIST , 0 , 0);
+
+		cm.addDistCache(CACHE_USERS, 30, 100 , DIST_AND_LOCAL , 30 , 100);
+		cm.addDistCache(CACHE_FILE_ENTRIES, 1 * HOUR + 40 * MIN, 100 , DIST_AND_LOCAL, 1 * HOUR + 40 * MIN, 100);
+
+		cm.addLocalCache(CACHE_RIGHT_PANEL_ENTRIES, 1 * DAY, 2);
+		cm.addLocalCache(CACHE_LEFT_PANEL_ENTRIES, 1 * DAY, 2);
+		cm.addLocalCache(CACHE_CURRENT_PERFTEST_STATISTICS, 5, 1);
+		cm.addLocalCache(CACHE_LOCAL_AGENTS, 1 * HOUR, 1);
+		return cm;
+	}
+
+	static class CacheConfigHolder {
+		enum Mode {
+			DIST,
+			LOCAL,
+			DIST_AND_LOCAL,
+		}
+
+		private final Map<String, MapConfig> hazelcastCacheConfigs = new ConcurrentHashMap<>();
+		private final Map<String, CacheBuilder<Object, Object>> guavaCacheConfig = new ConcurrentHashMap<>();
+
+		void addLocalCache(String cacheName, int timeout, int count) {
+			CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder().maximumSize(count).expireAfterWrite(timeout, TimeUnit.SECONDS);
+			guavaCacheConfig.put(cacheName, cacheBuilder);
+		}
+
+		void addDistCache(String cacheName, int timeout, int count, Mode mode, int nearCacheTimeout, int nearCacheCount) {
+			MapConfig mapConfig = new MapConfig(cacheName);
+			mapConfig.setTimeToLiveSeconds(timeout);
+			mapConfig.setMaxSizeConfig(new MaxSizeConfig(count, PER_NODE));
+			if (DIST_AND_LOCAL.equals(mode)) {
+				NearCacheConfig nearCacheConfig = new NearCacheConfig(cacheName);
+				nearCacheConfig.setTimeToLiveSeconds(nearCacheTimeout);
+				nearCacheConfig.setMaxSize(nearCacheCount);
+				mapConfig.setNearCacheConfig(nearCacheConfig);
+			}
+			hazelcastCacheConfigs.put(cacheName, mapConfig);
+		}
+
+		Map<String, MapConfig> getHazelcastCacheConfigs() {
+			return hazelcastCacheConfigs;
+		}
+
+		Map<String, CacheBuilder<Object, Object>> getGuavaCacheConfig() {
+			return guavaCacheConfig;
+		}
 	}
 
 	protected boolean isClustered() {
 		return config.isClustered();
 	}
 
-	private Pair<FactoryConfiguration, NetworkUtils.IPPortPair> createRMICacheManagerPeerProviderFactory
-			(Configuration cacheManagerConfig) {
-		FactoryConfiguration peerProviderConfig = new FactoryConfiguration();
-		peerProviderConfig.setClass(RMICacheManagerPeerProviderFactory.class.getName());
-
-		Pair<NetworkUtils.IPPortPair, String> properties;
-		if (StringUtils.equals(getClusterMode(), "advanced")) {
-			CoreLogger.LOGGER.info("In cluster - advanced mode.");
-			properties = createManualDiscoveryCacheProperties(getReplicatedCacheNames(cacheManagerConfig));
-		} else {
-			CoreLogger.LOGGER.info("In cluster - easy mode.");
-			properties = createAutoDiscoveryCacheProperties();
-		}
-
-		NetworkUtils.IPPortPair currentListener = properties.getFirst();
-		System.setProperty("java.rmi.server.hostname", currentListener.getFormattedIP());
-
-		String peers = properties.getSecond();
-		peerProviderConfig.setProperties(peers);
-		CoreLogger.LOGGER.info("peer provider is set as {}", peers);
-		return Pair.of(peerProviderConfig, currentListener);
-	}
-
 	protected String getClusterMode() {
-		return config.getClusterProperties().getProperty(ClusterConstants.PROP_CLUSTER_MODE, "advanced");
-	}
-
-	private FactoryConfiguration createPearListenerFactory(String ip, int port) {
-		FactoryConfiguration peerListenerConfig = new FactoryConfiguration();
-		peerListenerConfig.setClass(RMICacheManagerPeerListenerFactory.class.getName());
-		peerListenerConfig.setProperties(String.format("hostName=%s, port=%d, socketTimeoutMillis=3000", ip, port));
-		CoreLogger.LOGGER.info("peer listener is set as {}:{}", ip, port);
-		return peerListenerConfig;
+		return config.getClusterProperties().getProperty(PROP_CLUSTER_MODE, "advanced");
 	}
 
 	String getCacheName() {
 		return "cacheManager";
 	}
 
-
-	public Pair<NetworkUtils.IPPortPair, String> createAutoDiscoveryCacheProperties() {
-		// rmiUrls=//10.34.223.148:40003/distributed_map|//10.34.63.28:40003/distributed_map
-		NetworkUtils.IPPortPair local = new NetworkUtils.IPPortPair(getClusterHostName(), getClusterPort());
-		String peerProperty = "peerDiscovery=automatic, multicastGroupAddress=230.0.0.1,multicastGroupPort=4446, timeToLive=32";
-		return Pair.of(Preconditions.checkNotNull(local, "localhost ip does not exists in the cluster uris"),
-				peerProperty);
-	}
-
-	public Pair<NetworkUtils.IPPortPair, String> createManualDiscoveryCacheProperties(List<String> replicatedCacheNames) {
-		int clusterListenerPort = getClusterPort();
-		// rmiUrls=//10.34.223.148:40003/distributed_map|//10.34.63.28:40003/distributed_map
-		List<String> uris = new ArrayList<String>();
-		NetworkUtils.IPPortPair local = null;
-		for (String ip : getClusterURIs()) {
-			NetworkUtils.IPPortPair ipAndPortPair = NetworkUtils.convertIPAndPortPair(ip, clusterListenerPort);
-			if (ipAndPortPair.isLocalHost() && ipAndPortPair.getPort() == clusterListenerPort) {
-				local = ipAndPortPair;
-				continue;
-			}
-			for (String cacheName : replicatedCacheNames) {
-				uris.add(String.format("//%s/%s", ipAndPortPair.toString(), cacheName));
-			}
-		}
-
-		String peerProperty = "peerDiscovery=manual,rmiUrls=" + StringUtils.join(uris, "|");
-		return Pair.of(Preconditions.checkNotNull(local, "localhost ip does not exists in the cluster uris"),
-				peerProperty);
-	}
-
 	protected String[] getClusterURIs() {
 		return config.getClusterURIs();
 	}
 
-
 	public String getClusterHostName() {
-		String hostName = config.getClusterProperties().getProperty(PROP_CLUSTER_HOST, NetworkUtils.DEFAULT_LOCAL_HOST_ADDRESS);
+		String hostName = config.getClusterProperties().getProperty(PROP_CLUSTER_HOST, DEFAULT_LOCAL_HOST_ADDRESS);
 		try {
 			//noinspection ResultOfMethodCallIgnored
 			InetAddress.getByName(hostName);
@@ -218,5 +291,4 @@ public class DynamicCacheConfig implements ClusterConstants {
 	public void setConfig(Config config) {
 		this.config = config;
 	}
-
 }

--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/hazelcast/HazelcastService.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/hazelcast/HazelcastService.java
@@ -1,0 +1,92 @@
+package org.ngrinder.infra.hazelcast;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IExecutorService;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.Member;
+import org.ngrinder.common.exception.NGrinderRuntimeException;
+import org.ngrinder.infra.hazelcast.topic.message.TopicEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static org.ngrinder.common.constant.CacheConstants.REGION_ATTR_KEY;
+import static org.ngrinder.infra.hazelcast.topic.subscriber.TopicSubscriber.TOPIC_NAME;
+
+/**
+ * For support data clustering using hazelcast instance.
+ *
+ * @since 3.5.0
+ */
+@Service
+public class HazelcastService {
+
+	private Logger LOGGER = LoggerFactory.getLogger(HazelcastService.class);
+
+	@Autowired
+	@Qualifier("embeddedHazelcast")
+	private HazelcastInstance hazelcastInstance;
+
+	private Member findClusterMember(String region) {
+		Set<Member> clusterMember = hazelcastInstance.getCluster().getMembers();
+		for (Member member: clusterMember) {
+			if (member.getAttributes().containsKey(REGION_ATTR_KEY) && region.equals(member.getAttributes().get(REGION_ATTR_KEY))) {
+				return member;
+			}
+		}
+		throw new IllegalArgumentException(region + " is not clustered region.");
+	}
+
+	public <T> T submitToRegion(String executorName, Callable<T> task, String region) {
+		Member member = findClusterMember(region);
+		IExecutorService executorService = hazelcastInstance.getExecutorService(executorName);
+		Future<T> future = executorService.submitToMember(task, member);
+		try {
+			return future.get();
+		} catch (InterruptedException | ExecutionException e) {
+			LOGGER.error("Error while updating regions. {}", e.getMessage());
+			throw new NGrinderRuntimeException("Error while updating regions.");
+		}
+	}
+
+	public <T> List<T> submitToAllRegion(String executorName, Callable<T> task) {
+		List<T> results = new ArrayList<>();
+		IExecutorService executorService = hazelcastInstance.getExecutorService(executorName);
+		Map<Member, Future<T>> futures = executorService.submitToAllMembers(task);
+		for (Future<T> future : futures.values()) {
+			try {
+				T result = future.get();
+				results.add(result);
+			} catch (InterruptedException | ExecutionException e) {
+				LOGGER.error("Error while inquire region info. {}", e.getMessage());
+			}
+		}
+		return results;
+	}
+
+	public void publish(TopicEvent event) {
+		hazelcastInstance.getTopic(TOPIC_NAME).publish(event);
+	}
+
+	public void put(String mapName, Object key, Object value) {
+		hazelcastInstance.getMap(mapName).put(key, value);
+	}
+
+	public <K, V> V get(String mapName, K key) {
+		IMap<K, V> map = hazelcastInstance.getMap(mapName);
+		if (map == null) {
+			throw new NGrinderRuntimeException("Cache(" + mapName +") is not exist");
+		}
+		return map.get(key);
+	}
+}

--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/hazelcast/task/InquireAgentStateTask.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/hazelcast/task/InquireAgentStateTask.java
@@ -1,0 +1,36 @@
+package org.ngrinder.infra.hazelcast.task;
+
+import com.hazelcast.spring.context.SpringAware;
+import org.ngrinder.agent.service.AgentManagerService;
+import org.ngrinder.monitor.controller.model.SystemDataModel;
+import org.ngrinder.perftest.service.AgentManager;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.io.Serializable;
+import java.util.concurrent.Callable;
+
+/**
+ * Task for get agent system data
+ *
+ * @since 3.5.0
+ */
+@SpringAware
+public class InquireAgentStateTask implements Callable<SystemDataModel>, Serializable {
+	private String ip;
+	private String name;
+
+	public InquireAgentStateTask(String ip, String name) {
+		this.ip = ip;
+		this.name = name;
+	}
+
+	@Autowired
+	private transient AgentManagerService agentManagerService;
+
+	@Autowired
+	private transient AgentManager agentManager;
+
+	public SystemDataModel call() {
+		return agentManager.getSystemDataModel(agentManagerService.getAgentIdentityByIpAndName(ip, name));
+	}
+}

--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/hazelcast/task/InquireRegionAgentTask.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/hazelcast/task/InquireRegionAgentTask.java
@@ -1,0 +1,36 @@
+package org.ngrinder.infra.hazelcast.task;
+
+import com.google.common.collect.Sets;
+import com.hazelcast.spring.context.SpringAware;
+import net.grinder.common.processidentity.AgentIdentity;
+import net.grinder.util.NetworkUtils;
+import org.apache.commons.lang.StringUtils;
+import org.ngrinder.infra.config.Config;
+import org.ngrinder.perftest.service.AgentManager;
+import org.ngrinder.region.model.RegionInfo;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.concurrent.Callable;
+
+/**
+ * Task for get region info from clustered controller.
+ *
+ * @since 3.5.0
+ */
+@SpringAware
+public class InquireRegionAgentTask implements Callable<RegionInfo>, Serializable {
+
+	@Autowired
+	private transient AgentManager agentManager;
+
+	@Autowired
+	private transient Config config;
+
+	public RegionInfo call() {
+		HashSet<AgentIdentity> newHashSet = Sets.newHashSet(agentManager.getAllAttachedAgents());
+		final String regionIP = StringUtils.defaultIfBlank(config.getCurrentIP(), NetworkUtils.DEFAULT_LOCAL_HOST_ADDRESS);
+		return new RegionInfo(config.getRegion(), regionIP, config.getControllerPort(), newHashSet);
+	}
+}

--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/hazelcast/topic/listener/TopicListener.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/hazelcast/topic/listener/TopicListener.java
@@ -1,0 +1,10 @@
+package org.ngrinder.infra.hazelcast.topic.listener;
+
+import org.ngrinder.infra.hazelcast.topic.message.TopicEvent;
+
+/**
+ * @since 3.5.0
+ */
+public interface TopicListener<T> {
+	void execute(TopicEvent<T> event);
+}

--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/hazelcast/topic/message/TopicEvent.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/hazelcast/topic/message/TopicEvent.java
@@ -1,0 +1,43 @@
+package org.ngrinder.infra.hazelcast.topic.message;
+
+
+import java.io.Serializable;
+
+/**
+ * @since 3.5.0
+ */
+public class TopicEvent<T> implements Serializable {
+	private String type;
+	private String key;
+	private T data;
+
+	public TopicEvent(String type, String key, T data) {
+		this.type = type;
+		this.key = key;
+		this.data = data;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public String getKey() {
+		return key;
+	}
+
+	public void setKey(String key) {
+		this.key = key;
+	}
+
+	public T getData() {
+		return data;
+	}
+
+	public void setData(T data) {
+		this.data = data;
+	}
+}

--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/hazelcast/topic/subscriber/TopicSubscriber.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/hazelcast/topic/subscriber/TopicSubscriber.java
@@ -1,0 +1,37 @@
+package org.ngrinder.infra.hazelcast.topic.subscriber;
+
+
+import com.hazelcast.core.Message;
+import com.hazelcast.core.MessageListener;
+import org.ngrinder.infra.hazelcast.topic.listener.TopicListener;
+import org.ngrinder.infra.hazelcast.topic.message.TopicEvent;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @since 3.5.0
+ */
+@SuppressWarnings({"unused", "unchecked"})
+public class TopicSubscriber implements MessageListener<TopicEvent> {
+
+	public static final String TOPIC_NAME = "DEFAULT_TOPIC";
+
+	private Map<String, TopicListener> listenerMap = new HashMap<>();
+
+	@Override
+	public void onMessage(Message<TopicEvent> message) {
+		TopicEvent event = message.getMessageObject();
+		if (listenerMap.containsKey(event.getType())) {
+			listenerMap.get(event.getType()).execute(event);
+		}
+	}
+
+	public void addListener(String type, TopicListener listener) {
+		this.listenerMap.put(type, listener);
+	}
+
+	public void removeListener(String type) {
+		listenerMap.remove(type);
+	}
+}

--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/model/SamplingModel.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/model/SamplingModel.java
@@ -1,0 +1,26 @@
+package org.ngrinder.perftest.model;
+
+import java.io.Serializable;
+
+/**
+ * For modeling perf test running status
+ *
+ * @since 3.5.0
+ */
+public class SamplingModel implements Serializable {
+	private String runningSample;
+	private String agentState;
+
+	public SamplingModel(String runningSample, String agentState) {
+		this.runningSample = runningSample;
+		this.agentState = agentState;
+	}
+
+	public String getRunningSample() {
+		return runningSample;
+	}
+
+	public String getAgentState() {
+		return agentState;
+	}
+}

--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/repository/PerfTestRepository.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/repository/PerfTestRepository.java
@@ -63,18 +63,6 @@ public interface PerfTestRepository extends JpaRepository<PerfTest, Long>, JpaSp
 	List<PerfTest> findAllByStatusAndRegionOrderByScheduledTimeAsc(Status status, String region);
 
 	/**
-	 * Update the runtime statistics on the perf test having the given {@link PerfTest} id.
-	 *
-	 * @param id            {@link PerfTest} id
-	 * @param runningSample running sample json string
-	 * @param agentState    agent status json string
-	 * @return the count of updated row
-	 */
-	@Modifying
-	@Query("update PerfTest p set p.runningSample=?2, p.agentState=?3 where p.id=?1")
-	int updateRuntimeStatistics(Long id, String runningSample, String agentState);
-
-	/**
 	 * Update the monitor statistics on the perf test having the given {@link PerfTest} id.
 	 *
 	 * @param id            {@link PerfTest} id

--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/PerfTestService.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/PerfTestService.java
@@ -67,6 +67,7 @@ import java.io.*;
 import java.util.*;
 import java.util.Map.Entry;
 
+import static org.ngrinder.common.constant.CacheConstants.*;
 import static org.ngrinder.common.constants.MonitorConstants.MONITOR_FILE_PREFIX;
 import static org.ngrinder.common.util.AccessUtils.getSafe;
 import static org.ngrinder.common.util.CollectionUtils.*;
@@ -1060,7 +1061,7 @@ public class PerfTestService extends AbstractPerfTestService implements Controll
 	 *
 	 * @return PerfTestStatisticsList PerfTestStatistics list
 	 */
-	@Cacheable("current_perftest_statistics")
+	@Cacheable(CACHE_CURRENT_PERFTEST_STATISTICS)
 	@Transactional
 	public Collection<PerfTestStatistics> getCurrentPerfTestStatistics() {
 		Map<User, PerfTestStatistics> perfTestPerUser = newHashMap();
@@ -1161,7 +1162,7 @@ public class PerfTestService extends AbstractPerfTestService implements Controll
 			}
 			json = gson.toJson(systemInfo);
 		}
-		perfTestRepository.updatetMonitorStatus(perfTestId, json);
+		hazelcastService.put(CACHE_MONITORING , perfTestId , json);
 	}
 
 	/**

--- a/ngrinder-controller/src/main/java/org/ngrinder/region/model/RegionInfo.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/region/model/RegionInfo.java
@@ -13,10 +13,10 @@
  */
 package org.ngrinder.region.model;
 
+import net.grinder.common.processidentity.AgentIdentity;
+
 import java.io.Serializable;
 import java.util.Set;
-
-import net.grinder.common.processidentity.AgentIdentity;
 
 /**
  * Region info to be shared b/w controllers.
@@ -32,6 +32,7 @@ public class RegionInfo implements Serializable {
 	private Integer controllerPort;
 	private boolean visible = true;
 	private Set<AgentIdentity> agentIdentities;
+	private String regionName;
 
 
 	/**
@@ -41,8 +42,8 @@ public class RegionInfo implements Serializable {
 	 * @param controllerPort  controllerPort
 	 * @param agentIdentities agentIdentity Set
 	 */
-	public RegionInfo(String ip, int port, Set<AgentIdentity> agentIdentities) {
-		this(ip, port, agentIdentities, true);
+	public RegionInfo(String ip, int controllerPort, Set<AgentIdentity> agentIdentities) {
+		this(ip, controllerPort, agentIdentities, true);
 	}
 
 	/**
@@ -71,6 +72,13 @@ public class RegionInfo implements Serializable {
 		this.agentIdentities = agentIdentities;
 	}
 
+	public RegionInfo(String regionName , String ip, Integer controllerPort, Set<AgentIdentity> agentIdentities) {
+		this.ip = ip;
+		this.controllerPort = controllerPort;
+		this.agentIdentities = agentIdentities;
+		this.regionName = regionName;
+	}
+
 	public String getIp() {
 		return ip;
 	}
@@ -79,7 +87,6 @@ public class RegionInfo implements Serializable {
 		this.ip = ip;
 	}
 
-
 	public boolean isVisible() {
 		return visible;
 	}
@@ -87,7 +94,6 @@ public class RegionInfo implements Serializable {
 	public void setVisible(boolean visible) {
 		this.visible = visible;
 	}
-
 
 	public Set<AgentIdentity> getAgentIdentities() {
 		return agentIdentities;
@@ -99,5 +105,9 @@ public class RegionInfo implements Serializable {
 
 	public Integer getControllerPort() {
 		return controllerPort;
+	}
+
+	public String getRegionName() {
+		return this.regionName;
 	}
 }

--- a/ngrinder-controller/src/main/java/org/ngrinder/region/service/RegionService.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/region/service/RegionService.java
@@ -13,32 +13,31 @@
  */
 package org.ngrinder.region.service;
 
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-import net.grinder.common.processidentity.AgentIdentity;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.Member;
 import net.grinder.util.NetworkUtils;
-import net.sf.ehcache.Ehcache;
 import org.apache.commons.lang.StringUtils;
 import org.ngrinder.common.constant.ClusterConstants;
-import org.ngrinder.common.util.TypeConvertUtils;
+import org.ngrinder.common.exception.NGrinderRuntimeException;
 import org.ngrinder.infra.config.Config;
-import org.ngrinder.infra.schedule.ScheduledTaskService;
-import org.ngrinder.perftest.service.AgentManager;
+import org.ngrinder.infra.hazelcast.HazelcastService;
+import org.ngrinder.infra.hazelcast.task.InquireRegionAgentTask;
 import org.ngrinder.region.model.RegionInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.Cache;
-import org.springframework.cache.Cache.ValueWrapper;
-import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Map;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
 
+import static org.ngrinder.common.constant.CacheConstants.*;
 import static org.ngrinder.common.util.ExceptionUtils.processException;
 
 /**
@@ -58,27 +57,54 @@ public class RegionService {
 	private Config config;
 
 	@Autowired
-	private ScheduledTaskService scheduledTaskService;
+	private HazelcastService hazelcastService;
 
 	@Autowired
-	private CacheManager cacheManager;
+	@Qualifier("embeddedHazelcast")
+	private HazelcastInstance hazelcastInstance;
+
 	private Cache cache;
 
+	private Supplier<Map<String, RegionInfo>> allRegions = Suppliers.memoizeWithExpiration(new Supplier<Map<String, RegionInfo>>() {
+		@Override
+		public Map<String, RegionInfo> get() {
+			return inquireAllRegion();
+		}
+	}, REGION_CACHE_TIME_TO_LIVE_SECONDS, TimeUnit.SECONDS);
 
-	/**
-	 * Set current region into cache, using the IP as key and region name as value.
-	 */
+	private Supplier<List<String>> allRegionNames = Suppliers.memoizeWithExpiration(new Supplier<List<String>>() {
+		@Override
+		public List<String> get() {
+			return inquireAllVisibleRegionNames();
+		}
+	}, REGION_CACHE_TIME_TO_LIVE_SECONDS, TimeUnit.SECONDS);
+
+	private Map<String, RegionInfo> inquireAllRegion() {
+		Map<String, RegionInfo> regions = Maps.newHashMap();
+		if (config.isClustered()) {
+			List<RegionInfo> regionInfos = hazelcastService.submitToAllRegion(REGION_EXECUTOR_SERVICE_NAME, new InquireRegionAgentTask());
+			for (RegionInfo regionInfo: regionInfos) {
+				regions.put(regionInfo.getRegionName(), regionInfo);
+			}
+		}
+		return regions;
+	}
+
+	private List<String> inquireAllVisibleRegionNames() {
+		Set<Member> members = hazelcastInstance.getCluster().getMembers();
+		List<String> regionNames = new ArrayList<>();
+		for (Member member: members) {
+			if (member.getAttributes().containsKey(REGION_ATTR_KEY)) {
+				regionNames.add((String) member.getAttributes().get(REGION_ATTR_KEY));
+			}
+		}
+		return regionNames;
+	}
+
 	@PostConstruct
 	public void initRegion() {
 		if (config.isClustered()) {
-			cache = cacheManager.getCache("regions");
 			verifyDuplicatedRegion();
-			scheduledTaskService.addFixedDelayedScheduledTask(new Runnable() {
-				@Override
-				public void run() {
-					checkRegionUpdate();
-				}
-			}, 3000);
 		}
 	}
 
@@ -99,25 +125,6 @@ public class RegionService {
 		}
 	}
 
-	@Autowired
-	private AgentManager agentManager;
-
-	/**
-	 * check Region and Update its value.
-	 */
-	public void checkRegionUpdate() {
-		if (!config.isInvisibleRegion()) {
-			try {
-				HashSet<AgentIdentity> newHashSet = Sets.newHashSet(agentManager.getAllAttachedAgents());
-				final String regionIP = StringUtils.defaultIfBlank(config.getCurrentIP(), NetworkUtils.DEFAULT_LOCAL_HOST_ADDRESS);
-				cache.put(getCurrent(), new RegionInfo(regionIP, config.getControllerPort(), newHashSet));
-			} catch (Exception e) {
-				LOGGER.error("Error while updating regions. {}", e.getMessage());
-			}
-		}
-	}
-
-
 	/**
 	 * Get current region. This method returns where this service is running.
 	 *
@@ -130,11 +137,15 @@ public class RegionService {
 	/**
 	 * Get region by region name
 	 *
-	 * @param regionName
+	 * @param regionName region name for get region information
 	 * @return region info
 	 */
 	public RegionInfo getOne(String regionName) {
-		return (RegionInfo) cache.get(regionName).get();
+		RegionInfo regionInfo = getAll().get(regionName);
+		if (regionInfo != null) {
+			return regionInfo;
+		}
+		throw new NGrinderRuntimeException(regionName + "is not exist");
 	}
 
 	/**
@@ -143,36 +154,18 @@ public class RegionService {
 	 * @return region list
 	 */
 	public Map<String, RegionInfo> getAll() {
-		Map<String, RegionInfo> regions = Maps.newHashMap();
-		if (config.isClustered()) {
-			for (Object eachKey : ((Ehcache) (cache.getNativeCache())).getKeysWithExpiryCheck()) {
-				ValueWrapper valueWrapper = cache.get(eachKey);
-				if (valueWrapper != null && valueWrapper.get() != null) {
-					regions.put((String) eachKey, (RegionInfo) valueWrapper.get());
-				}
-			}
-		}
-		return regions;
+		return allRegions.get();
 	}
 
-	public ArrayList<String> getAllVisibleRegionNames() {
-		final ArrayList<String> regions = new ArrayList<String>();
+	public List<String> getAllVisibleRegionNames() {
 		if (config.isClustered()) {
-			for (Object eachKey : ((Ehcache) (cache.getNativeCache())).getKeysWithExpiryCheck()) {
-				ValueWrapper valueWrapper = cache.get(eachKey);
-				if (valueWrapper != null && valueWrapper.get() != null) {
-					final RegionInfo region = TypeConvertUtils.cast(valueWrapper.get());
-					if (region.isVisible()) {
-						regions.add((String) eachKey);
-					}
-				}
-			}
+			return allRegionNames.get();
+		} else {
+			return Collections.emptyList();
 		}
-		Collections.sort(regions);
-		return regions;
 	}
 
-	Config getConfig() {
+	public Config getConfig() {
 		return config;
 	}
 

--- a/ngrinder-controller/src/main/java/org/ngrinder/script/service/FileEntryService.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/script/service/FileEntryService.java
@@ -52,6 +52,7 @@ import java.util.Map;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Collections.unmodifiableList;
+import static org.ngrinder.common.constant.CacheConstants.CACHE_FILE_ENTRIES;
 import static org.ngrinder.common.util.CollectionUtils.buildMap;
 import static org.ngrinder.common.util.CollectionUtils.newHashMap;
 import static org.ngrinder.common.util.ExceptionUtils.processException;
@@ -99,7 +100,7 @@ public class FileEntryService {
 		// Add cache invalidation hook.
 		FSHooks.registerHook(new FSHook() {
 			@Override
-			public void onHook(FSHookEvent event) throws SVNException {
+			public void onHook(FSHookEvent event) {
 				if (event.getType().equals(FSHooks.SVN_REPOS_HOOK_POST_COMMIT)) {
 					String name = event.getReposRootDir().getName();
 					invalidateCache(name);
@@ -107,7 +108,7 @@ public class FileEntryService {
 			}
 		});
 		svnClientManager = fileEntityRepository.getSVNClientManager();
-		fileEntryCache = cacheManager.getCache("file_entries");
+		fileEntryCache = cacheManager.getCache(CACHE_FILE_ENTRIES);
 
 	}
 
@@ -154,7 +155,7 @@ public class FileEntryService {
 	 * @param user user
 	 * @return cached {@link FileEntry} list
 	 */
-	@Cacheable(value = "file_entries", key = "#user.userId")
+	@Cacheable(value = CACHE_FILE_ENTRIES, key = "#user.userId")
 	public List<FileEntry> getAll(User user) {
 		prepare(user);
 		List<FileEntry> allFileEntries;

--- a/ngrinder-controller/src/main/java/org/ngrinder/user/service/UserService.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/user/service/UserService.java
@@ -48,6 +48,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import static org.ngrinder.common.constant.CacheConstants.CACHE_USERS;
+
 /**
  * The Class UserService.
  *
@@ -87,7 +89,7 @@ public class UserService extends AbstractUserService {
 
 	@PostConstruct
 	public void init() {
-		userCache = cacheManager.getCache("users");
+		userCache = cacheManager.getCache(CACHE_USERS);
 		userModelCache = cacheManager.getCache("org.ngrinder.model.User");
 	}
 
@@ -98,7 +100,7 @@ public class UserService extends AbstractUserService {
 	 * @return user
 	 */
 	@Transactional
-	@Cacheable("users")
+	@Cacheable(CACHE_USERS)
 	@Override
 	public User getOne(String userId) {
 		return userRepository.findOneByUserId(userId);
@@ -139,7 +141,7 @@ public class UserService extends AbstractUserService {
 	 * @return User
 	 */
 	@Transactional
-	@CachePut(value = "users", key = "#user.userId")
+	@CachePut(value = CACHE_USERS, key = "#user.userId")
 	@Override
 	public User save(User user) {
 		encodePassword(user);
@@ -153,7 +155,7 @@ public class UserService extends AbstractUserService {
 	 * @return User
 	 */
 	@Transactional
-	@CachePut(value = "users", key = "#user.userId")
+	@CachePut(value = CACHE_USERS, key = "#user.userId")
 	@Override
 	public User saveWithoutPasswordEncoding(User user) {
 		final List<User> followers = getFollowers(user.getFollowersStr());
@@ -207,7 +209,7 @@ public class UserService extends AbstractUserService {
 	 */
 	@SuppressWarnings("SpringElInspection")
 	@Transactional
-	@CacheEvict(value = "users", key = "#userId")
+	@CacheEvict(value = CACHE_USERS, key = "#userId")
 	public void delete(String userId) {
 		User user = getOne(userId);
 		List<PerfTest> deletePerfTests = perfTestService.deleteAll(user);
@@ -279,7 +281,7 @@ public class UserService extends AbstractUserService {
 	 * @return User
 	 */
 	@Transactional
-	@CachePut(value = "users", key = "#user.userId")
+	@CachePut(value = CACHE_USERS, key = "#user.userId")
 	@Override
 	public User createUser(User user) {
 		encodePassword(user);

--- a/ngrinder-controller/src/main/resources/templates/ftl/agent/detail.ftl
+++ b/ngrinder-controller/src/main/resources/templates/ftl/agent/detail.ftl
@@ -129,8 +129,8 @@
     });
 
     function getState() {
-        var ajaxObj = new AjaxObj("/agent/api/{agentId}/state");
-        ajaxObj.params = { 'ip': '${(agent.ip)!}', 'name': '${(agent.hostName)!}', 'imgWidth': 700, agentId:${agent.id} };
+        var ajaxObj = new AjaxObj("/agent/api/state");
+        ajaxObj.params = { 'ip': '${(agent.ip)!}', 'name': '${(agent.hostName)!}', 'region': '${(agent.region)!}', 'imgWidth': 700, };
         ajaxObj.success = function (res) {
             cpuUsage.enQueue(res.cpuUsedPercentage);
             memoryUsage.enQueue(res.totalMemory - res.freeMemory);
@@ -140,7 +140,7 @@
         };
 		ajaxObj.error = function() {
 			window.clearInterval(timer)
-		}
+		};
         ajaxObj.call();
     }
 

--- a/ngrinder-core/src/main/java/org/ngrinder/service/IAgentManagerService.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/service/IAgentManagerService.java
@@ -131,9 +131,10 @@ public interface IAgentManagerService {
 	 *
 	 * @param ip   agent ip.
 	 * @param name agent name
+	 * @param region region name
 	 * @return {@link SystemDataModel} instance.
 	 */
-	public abstract SystemDataModel getSystemDataModel(String ip, String name);
+	public abstract SystemDataModel getSystemDataModel(String ip, String name, String region);
 
 	/**
 	 * Update agent


### PR DESCRIPTION
Change to use `hazelcast` instead of `ehcache` for distributed cache and data sharing with clustered controllers.

