### PR TITLE
Fixed bug where parent fields could not be merged before saving.

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/init/DBInit.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/init/DBInit.java
@@ -100,7 +100,13 @@ public class DBInit {
 			user.setRole(role);
 			user.setUserName(userName);
 			user.setEmail(email);
-			user.setCreatedDate(new Date());
+
+			Date now = new Date();
+			user.setCreatedDate(now);
+			user.setLastModifiedDate(now);
+			user.setCreatedUser(user);
+			user.setLastModifiedUser(user);
+
 			user = userRepository.save(user);
 			fileEntryService.prepare(user);
 		}

--- a/ngrinder-core/src/main/java/org/ngrinder/model/BaseEntity.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/model/BaseEntity.java
@@ -16,11 +16,13 @@ package org.ngrinder.model;
 import com.google.gson.annotations.Expose;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
+import org.ngrinder.common.util.ReflectionUtils;
 
 import javax.persistence.*;
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.List;
 
 import static org.ngrinder.common.util.ExceptionUtils.processException;
 
@@ -79,7 +81,7 @@ public class BaseEntity<M> implements Serializable {
 	public M merge(M source) {
 		Field forDisplay = null;
 		try {
-			Field[] fields = getClass().getDeclaredFields();
+			List<Field> fields = ReflectionUtils.getDeclaredFieldsIncludingParent(getClass());
 			// Iterate over all the attributes
 			for (Field each : fields) {
 				if (each.isSynthetic()) {

--- a/ngrinder-core/src/test/java/org/ngrinder/common/util/ReflectionUtilTest.java
+++ b/ngrinder-core/src/test/java/org/ngrinder/common/util/ReflectionUtilTest.java
@@ -13,11 +13,16 @@
  */
 package org.ngrinder.common.util;
 
+import org.junit.Test;
+import org.ngrinder.model.BaseEntity;
+import org.ngrinder.model.BaseModel;
+import org.ngrinder.model.User;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-
-import org.junit.Test;
-import org.ngrinder.model.User;
 
 /**
  * Class description.
@@ -37,5 +42,12 @@ public class ReflectionUtilTest {
 		testUser.setUserId("TMP_UID");
 		String rtnUid = (String) ReflectionUtils.getFieldValue(testUser, "userId");
 		assertThat(rtnUid, is("TMP_UID"));
+	}
+
+	@Test
+	public void testGetDeclaredFieldsIncludingParent() {
+		List<Field> fields = ReflectionUtils.getDeclaredFieldsIncludingParent(User.class);
+		int UserObjectDeclaredFields = User.class.getDeclaredFields().length + BaseModel.class.getDeclaredFields().length + BaseEntity.class.getDeclaredFields().length;
+		assertThat(fields.size(), is(UserObjectDeclaredFields));
 	}
 }


### PR DESCRIPTION
1. Add last modified date and user when init user table.
2. Fixed bug where parent fields could not be merged before saving.
     - `getClass().getDeclaredFields()` could not resolve parent fields.
