### PR TITLE
Add custom error controller

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/error/controller/DefaultErrorController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/error/controller/DefaultErrorController.java
@@ -1,0 +1,29 @@
+package org.ngrinder.error.controller;
+
+import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static javax.servlet.RequestDispatcher.ERROR_STATUS_CODE;
+import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+
+@Controller
+public class DefaultErrorController implements ErrorController {
+
+	private static final String ERROR_HANDLING_PATH = "/error";
+
+	@RequestMapping(ERROR_HANDLING_PATH)
+	public String handleError(HttpServletRequest request) {
+		if (request.getAttribute(ERROR_STATUS_CODE).equals(SC_NOT_FOUND)) {
+			return "redirect:/doError?type=404";
+		}
+		return "redirect:/doError";
+	}
+
+	@Override
+	public String getErrorPath() {
+		return ERROR_HANDLING_PATH;
+	}
+}


### PR DESCRIPTION
Disable default whitelabel error page supported by springboot and add custom error controller.
#### - Before
![image](https://user-images.githubusercontent.com/14273601/52837667-02b4b080-3133-11e9-8e5a-cbdb208d3474.png)

#### - After
![image](https://user-images.githubusercontent.com/14273601/52837515-638fb900-3132-11e9-9e85-550d1f50b583.png)
