### PR TITLE
Disable hazelcast all join method when run with non-cluster mode

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/config/DynamicCacheConfig.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/config/DynamicCacheConfig.java
@@ -99,7 +99,6 @@ public class DynamicCacheConfig implements ClusterConstants {
 
 		if (isClustered() && getClusterURIs() != null && getClusterURIs().length > 0) {
 			JoinConfig join = networkConfig.getJoin();
-			join.getAwsConfig().setEnabled(false);
 			join.getMulticastConfig().setEnabled(false);
 			TcpIpConfig tcpIpConfig = join.getTcpIpConfig();
 			tcpIpConfig.setEnabled(true);
@@ -107,9 +106,7 @@ public class DynamicCacheConfig implements ClusterConstants {
 			networkConfig.setPublicAddress(selectLocalIp(Arrays.asList(getClusterURIs())));
 		} else {
 			JoinConfig join = networkConfig.getJoin();
-			join.getAwsConfig().setEnabled(false);
-			join.getTcpIpConfig().setEnabled(false);
-			join.getMulticastConfig().setEnabled(true);
+			join.getMulticastConfig().setEnabled(false);
 		}
 
 		HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance(hazelcastConfig);


### PR DESCRIPTION
Disable hazelcast all join mechanism when run with non-cluster mode.

`2019-02-20 17:55:53,948 WARN  StandardLoggerFactory.java:49  [dev] [3.11.1] No join method is enabled! Starting standalone.`