### PR TITLE
Apply lastet update merge policy to hazelcast map configuration

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/config/DynamicCacheConfig.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/config/DynamicCacheConfig.java
@@ -169,25 +169,26 @@ public class DynamicCacheConfig implements ClusterConstants {
 		}
 
 		void addDistCache(String cacheName, int timeout, int count, int nearCacheTimeout, int nearCacheCount) {
-			MapConfig mapConfig = new MapConfig(cacheName);
-			mapConfig.getMergePolicyConfig().setPolicy(LatestUpdateMergePolicy.class.getName());
-			mapConfig.setTimeToLiveSeconds(timeout);
-			mapConfig.setMaxSizeConfig(new MaxSizeConfig(count, PER_NODE));
+			MapConfig mapConfig = createDistMapConfig(cacheName, timeout, count);
 
 			NearCacheConfig nearCacheConfig = new NearCacheConfig(cacheName);
 			nearCacheConfig.setTimeToLiveSeconds(nearCacheTimeout);
-			nearCacheConfig.setMaxSize(nearCacheCount);
+			nearCacheConfig.getEvictionConfig().setSize(nearCacheCount);
 			mapConfig.setNearCacheConfig(nearCacheConfig);
 
 			hazelcastCacheConfigs.put(cacheName, mapConfig);
 		}
 
 		void addDistMap(String cacheName, int timeout, int count) {
+			hazelcastCacheConfigs.put(cacheName, createDistMapConfig(cacheName, timeout, count));
+		}
+
+		private MapConfig createDistMapConfig(String cacheName, int timeout, int count) {
 			MapConfig mapConfig = new MapConfig(cacheName);
 			mapConfig.getMergePolicyConfig().setPolicy(LatestUpdateMergePolicy.class.getName());
 			mapConfig.setTimeToLiveSeconds(timeout);
-			mapConfig.setMaxSizeConfig(new MaxSizeConfig(count, PER_NODE));
-			hazelcastCacheConfigs.put(cacheName, mapConfig);
+			mapConfig.getMaxSizeConfig().setSize(count).setMaxSizePolicy(PER_NODE);
+			return mapConfig;
 		}
 
 		Map<String, MapConfig> getHazelcastCacheConfigs() {

--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/config/DynamicCacheConfig.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/config/DynamicCacheConfig.java
@@ -18,6 +18,7 @@ import com.hazelcast.config.*;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ITopic;
+import com.hazelcast.spi.merge.LatestUpdateMergePolicy;
 import com.hazelcast.spring.cache.HazelcastCacheManager;
 import com.hazelcast.spring.context.SpringManagedContext;
 import net.grinder.util.NetworkUtils;
@@ -169,6 +170,7 @@ public class DynamicCacheConfig implements ClusterConstants {
 
 		void addDistCache(String cacheName, int timeout, int count, int nearCacheTimeout, int nearCacheCount) {
 			MapConfig mapConfig = new MapConfig(cacheName);
+			mapConfig.getMergePolicyConfig().setPolicy(LatestUpdateMergePolicy.class.getName());
 			mapConfig.setTimeToLiveSeconds(timeout);
 			mapConfig.setMaxSizeConfig(new MaxSizeConfig(count, PER_NODE));
 
@@ -182,6 +184,7 @@ public class DynamicCacheConfig implements ClusterConstants {
 
 		void addDistMap(String cacheName, int timeout, int count) {
 			MapConfig mapConfig = new MapConfig(cacheName);
+			mapConfig.getMergePolicyConfig().setPolicy(LatestUpdateMergePolicy.class.getName());
 			mapConfig.setTimeToLiveSeconds(timeout);
 			mapConfig.setMaxSizeConfig(new MaxSizeConfig(count, PER_NODE));
 			hazelcastCacheConfigs.put(cacheName, mapConfig);


### PR DESCRIPTION
Sometimes when running controller with cluster mode, hazelcast split brain syndrome was occurred.
so i apply lastet update merge policy to resolve it.