### PR TITLE
Make to use spring default json serialization in controller

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ subprojects {
     hazelcast_version = "3.11.1"
     gson_version = "2.8.0"
     mockito_version = "2.15.0"
+    jackson_version = "2.9.0"
   }
 
   repositories {

--- a/ngrinder-controller/src/main/java/org/ngrinder/agent/controller/AgentManagerApiController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/agent/controller/AgentManagerApiController.java
@@ -1,0 +1,207 @@
+/* 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. 
+ */
+package org.ngrinder.agent.controller;
+
+import org.apache.commons.lang.StringUtils;
+import org.ngrinder.common.controller.RestAPI;
+import org.ngrinder.model.AgentInfo;
+import org.ngrinder.model.User;
+import org.ngrinder.monitor.controller.model.SystemDataModel;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.ngrinder.common.util.CollectionUtils.buildMap;
+
+/**
+ * Agent management api controller.
+ *
+ * @since 3.5.0
+ */
+@RestController
+@RequestMapping("/agent")
+@PreAuthorize("hasAnyRole('A', 'S')")
+public class AgentManagerApiController extends AgentManagerBaseController {
+
+	/**
+	 * Clean up the agents in the inactive region
+	 */
+	@RestAPI
+	@PreAuthorize("hasAnyRole('A')")
+	@RequestMapping(value = "/api", params = "action=cleanup", method = RequestMethod.POST)
+	public String cleanUpAgentsInInactiveRegion() {
+		agentManagerService.cleanup();
+		return returnSuccess();
+	}
+
+	/**
+	 * Get the current performance of the given agent.
+	 *
+	 * @param ip agent ip
+	 * @param name agent name
+	 * @param region agent region
+	 *
+	 * @return json message
+	 */
+	@RestAPI
+	@PreAuthorize("hasAnyRole('A')")
+	@GetMapping("/api/state")
+	public SystemDataModel getState(@RequestParam String ip, @RequestParam String name, @RequestParam String region) {
+		return agentManagerService.getSystemDataModel(ip, name, region);
+	}
+
+	/**
+	 * Get the current all agents state.
+	 *
+	 * @return json message
+	 */
+	@RestAPI
+	@PreAuthorize("hasAnyRole('A', 'S', 'U')")
+	@RequestMapping({"/api/states/", "/api/states"})
+	public List<Map<String, Object>> getStates() {
+		List<AgentInfo> agents = agentManagerService.getAllVisible();
+		return getAgentStatus(agents);
+	}
+
+	/**
+	 * Get all agents from database.
+	 *
+	 * @return json message
+	 */
+	@RestAPI
+	@PreAuthorize("hasAnyRole('A')")
+	@RequestMapping({"/api/", "/api"})
+	public List<AgentInfo> getAll() {
+		return agentManagerService.getAllVisible();
+	}
+
+	/**
+	 * Get the agent for the given agent id.
+	 *
+	 * @return json message
+	 */
+	@RestAPI
+	@PreAuthorize("hasAnyRole('A')")
+	@RequestMapping(value = "/api/{id}", method = RequestMethod.GET)
+	public AgentInfo getOne(@PathVariable("id") Long id) {
+		return agentManagerService.getOne(id);
+	}
+
+	/**
+	 * Approve an agent.
+	 *
+	 * @param id agent id
+	 * @return json message
+	 */
+	@RestAPI
+	@PreAuthorize("hasAnyRole('A')")
+	@RequestMapping(value = "/api/{id}", params = "action=approve", method = RequestMethod.PUT)
+	public String approve(@PathVariable("id") Long id) {
+		agentManagerService.approve(id, true);
+		return returnSuccess();
+	}
+
+	/**
+	 * Disapprove an agent.
+	 *
+	 * @param id agent id
+	 * @return json message
+	 */
+	@RestAPI
+	@PreAuthorize("hasAnyRole('A')")
+	@RequestMapping(value = "/api/{id}", params = "action=disapprove", method = RequestMethod.PUT)
+	public String disapprove(@PathVariable("id") Long id) {
+		agentManagerService.approve(id, false);
+		return returnSuccess();
+	}
+
+	/**
+	 * Stop the given agent.
+	 *
+	 * @param id agent id
+	 * @return json message
+	 */
+	@RestAPI
+	@PreAuthorize("hasAnyRole('A')")
+	@RequestMapping(value = "/api/{id}", params = "action=stop", method = RequestMethod.PUT)
+	public String stop(@PathVariable("id") Long id) {
+		agentManagerService.stopAgent(id);
+		return returnSuccess();
+	}
+
+	/**
+	 * Stop the given agent.
+	 *
+	 * @param ids comma separated agent id list
+	 * @return json message
+	 */
+	@RestAPI
+	@PreAuthorize("hasAnyRole('A')")
+	@RequestMapping(value = "/api", params = "action=stop", method = RequestMethod.PUT)
+	public String stop(@RequestParam("ids") String ids) {
+		String[] split = StringUtils.split(ids, ",");
+		for (String each : split) {
+			stop(Long.parseLong(each));
+		}
+		return returnSuccess();
+	}
+
+	/**
+	 * Update the given agent.
+	 *
+	 * @param id agent id
+	 * @return json message
+	 */
+	@RestAPI
+	@PreAuthorize("hasAnyRole('A')")
+	@RequestMapping(value = "/api/{id}", params = "action=update", method = RequestMethod.PUT)
+	public String update(@PathVariable("id") Long id) {
+		agentManagerService.update(id);
+		return returnSuccess();
+	}
+
+	/**
+	 * Send update message to agent side
+	 *
+	 * @param ids comma separated agent id list
+	 * @return json message
+	 */
+	@RestAPI
+	@PreAuthorize("hasAnyRole('A')")
+	@RequestMapping(value = "/api", params = "action=update", method = RequestMethod.PUT)
+	public String update(@RequestParam("ids") String ids) {
+		String[] split = StringUtils.split(ids, ",");
+		for (String each : split) {
+			update(Long.parseLong(each));
+		}
+		return returnSuccess();
+	}
+
+	/**
+	 * Get the number of available agents.
+	 * 
+	 * @param user The login user
+	 * @param targetRegion The name of target region
+	 * @return availableAgentCount Available agent count
+	 */
+	@RestAPI
+	@RequestMapping("/api/availableAgentCount")
+	@PreAuthorize("permitAll")
+	public Map<String, Object> getAvailableAgentCount(User user, @RequestParam(value = "targetRegion", required = true) String targetRegion) {
+		int availableAgentCount = agentManagerService.getReadyAgentCount(user, targetRegion);
+		return buildMap("availableAgentCount", availableAgentCount);
+	}
+}

--- a/ngrinder-controller/src/main/java/org/ngrinder/agent/controller/AgentManagerBaseController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/agent/controller/AgentManagerBaseController.java
@@ -1,0 +1,87 @@
+/* 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. 
+ */
+package org.ngrinder.agent.controller;
+
+import org.apache.commons.lang.StringUtils;
+import org.ngrinder.agent.service.AgentManagerService;
+import org.ngrinder.common.controller.BaseController;
+import org.ngrinder.model.AgentInfo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.ngrinder.common.util.CollectionUtils.newArrayList;
+import static org.ngrinder.common.util.CollectionUtils.newHashMap;
+import static org.ngrinder.common.util.SpringSecurityUtils.containsAuthority;
+
+/**
+ * Agent management base controller.
+ *
+ * @since 3.5.0
+ */
+public class AgentManagerBaseController extends BaseController {
+
+	@Autowired
+	protected AgentManagerService agentManagerService;
+
+	/**
+	 * Filter agent list by referring to cluster
+	 */
+	protected boolean filterAgentByCluster(String region, String agentRegion) {
+		//noinspection SimplifiableIfStatement
+		if (StringUtils.isEmpty(region)) {
+			return true;
+		} else {
+			return agentRegion.startsWith(region + "_owned") || region.equals(agentRegion);
+		}
+	}
+
+	/**
+	 * Filter agent list using user authority and user id
+	 */
+	protected boolean filterAgentByUserAuthorityAndId(Collection<? extends GrantedAuthority> authorities, String userId, String region, String agentRegion) {
+		if (isAdminOrSuperUser(authorities)) {
+			return true;
+		}
+
+		if (StringUtils.isEmpty(region)) {
+			return !agentRegion.contains("_owned_") || agentRegion.endsWith("_owned_" + userId);
+		} else {
+			return agentRegion.startsWith(region + "_owned_" + userId) ||  region.equals(agentRegion);
+		}
+	}
+
+	/**
+	 * Check if the current user is admin or super user
+	 */
+	protected boolean isAdminOrSuperUser(Collection<? extends GrantedAuthority> authorities) {
+		return containsAuthority(authorities, "A") || containsAuthority(authorities, "S");
+	}
+
+	protected List<Map<String, Object>> getAgentStatus(List<AgentInfo> agents) {
+		List<Map<String, Object>> statuses = newArrayList(agents.size());
+		for (AgentInfo each : agents) {
+			Map<String, Object> result = newHashMap();
+			result.put("id", each.getId());
+			result.put("port", each.getPort());
+			result.put("icon", each.getState().getCategory().getIconName());
+			result.put("state", each.getState());
+			statuses.add(result);
+		}
+		return statuses;
+	}
+}

--- a/ngrinder-controller/src/main/java/org/ngrinder/agent/controller/AgentManagerController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/agent/controller/AgentManagerController.java
@@ -15,33 +15,24 @@ package org.ngrinder.agent.controller;
 
 import com.google.common.base.Predicate;
 import org.apache.commons.lang.StringUtils;
-import org.ngrinder.agent.service.AgentManagerService;
 import org.ngrinder.agent.service.AgentPackageService;
-import org.ngrinder.common.controller.BaseController;
-import org.ngrinder.common.controller.RestAPI;
 import org.ngrinder.model.AgentInfo;
 import org.ngrinder.model.User;
 import org.ngrinder.region.model.RegionInfo;
 import org.ngrinder.region.service.RegionService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.io.File;
 import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 
 import static com.google.common.collect.Collections2.filter;
-import static org.ngrinder.common.util.CollectionUtils.*;
-import static org.ngrinder.common.util.SpringSecurityUtils.containsAuthority;
 import static org.ngrinder.common.util.SpringSecurityUtils.getCurrentAuthorities;
 
 /**
@@ -53,11 +44,7 @@ import static org.ngrinder.common.util.SpringSecurityUtils.getCurrentAuthorities
 @Controller
 @RequestMapping("/agent")
 @PreAuthorize("hasAnyRole('A', 'S')")
-public class AgentManagerController extends BaseController {
-
-	@SuppressWarnings("SpringJavaAutowiringInspection")
-	@Autowired
-	private AgentManagerService agentManagerService;
+public class AgentManagerController extends AgentManagerBaseController {
 
 	@Autowired
 	private RegionService regionService;
@@ -107,40 +94,6 @@ public class AgentManagerController extends BaseController {
 	}
 
 	/**
-	 * Filter agent list by referring to cluster
-	 */
-	private boolean filterAgentByCluster(String region, String agentRegion) {
-		//noinspection SimplifiableIfStatement
-		if (StringUtils.isEmpty(region)) {
-			return true;
-		} else {
-			return agentRegion.startsWith(region + "_owned") || region.equals(agentRegion);
-		}
-	}
-
-	/**
-	 * Filter agent list using user authority and user id
-	 */
-	private boolean filterAgentByUserAuthorityAndId(Collection<? extends GrantedAuthority> authorities, String userId, String region, String agentRegion) {
-		if (isAdminOrSuperUser(authorities)) {
-			return true;
-		}
-
-		if (StringUtils.isEmpty(region)) {
-			return !agentRegion.contains("_owned_") || agentRegion.endsWith("_owned_" + userId);
-		} else {
-			return agentRegion.startsWith(region + "_owned_" + userId) ||  region.equals(agentRegion);
-		}
-	}
-
-	/**
-	 * Check if the current user is admin or super user
-	 */
-	private boolean isAdminOrSuperUser(Collection<? extends GrantedAuthority> authorities) {
-		return containsAuthority(authorities, "A") || containsAuthority(authorities, "S");
-	}
-
-	/**
 	 * Get the agent detail info for the given agent id.
 	 *
 	 * @param id    agent id
@@ -152,190 +105,4 @@ public class AgentManagerController extends BaseController {
 		model.addAttribute("agent", agentManagerService.getOne(id));
 		return "agent/detail";
 	}
-
-	/**
-	 * Clean up the agents in the inactive region
-	 */
-
-	@PreAuthorize("hasAnyRole('A')")
-	@RequestMapping(value = "/api", params = "action=cleanup", method = RequestMethod.POST)
-	public HttpEntity<String> cleanUpAgentsInInactiveRegion() {
-		agentManagerService.cleanup();
-		return successJsonHttpEntity();
-	}
-
-	/**
-	 * Get the current performance of the given agent.
-	 *
-	 * @param ip agent ip
-	 * @param name agent name
-	 * @param region agent region
-	 *
-	 * @return json message
-	 */
-
-	@PreAuthorize("hasAnyRole('A')")
-	@RequestMapping("/api/state")
-	public HttpEntity<String> getState(@RequestParam String ip, @RequestParam String name, @RequestParam String region) {
-		return toJsonHttpEntity(agentManagerService.getSystemDataModel(ip, name, region));
-	}
-
-	/**
-	 * Get the current all agents state.
-	 *
-	 * @return json message
-	 */
-	@RestAPI
-	@PreAuthorize("hasAnyRole('A', 'S', 'U')")
-	@RequestMapping(value = {"/api/states/", "/api/states"}, method = RequestMethod.GET)
-	public HttpEntity<String> getStates() {
-		List<AgentInfo> agents = agentManagerService.getAllVisible();
-		return toJsonHttpEntity(getAgentStatus(agents));
-	}
-
-	/**
-	 * Get all agents from database.
-	 *
-	 * @return json message
-	 */
-	@RestAPI
-	@PreAuthorize("hasAnyRole('A')")
-	@RequestMapping(value = {"/api/", "/api"}, method = RequestMethod.GET)
-	public HttpEntity<String> getAll() {
-		return toJsonHttpEntity(agentManagerService.getAllVisible());
-	}
-
-	/**
-	 * Get the agent for the given agent id.
-	 *
-	 * @return json message
-	 */
-	@RestAPI
-	@PreAuthorize("hasAnyRole('A')")
-	@RequestMapping(value = "/api/{id}", method = RequestMethod.GET)
-	public HttpEntity<String> getOne(@PathVariable("id") Long id) {
-		return toJsonHttpEntity(agentManagerService.getOne(id));
-	}
-
-	/**
-	 * Approve an agent.
-	 *
-	 * @param id agent id
-	 * @return json message
-	 */
-	@RestAPI
-	@PreAuthorize("hasAnyRole('A')")
-	@RequestMapping(value = "/api/{id}", params = "action=approve", method = RequestMethod.PUT)
-	public HttpEntity<String> approve(@PathVariable("id") Long id) {
-		agentManagerService.approve(id, true);
-		return successJsonHttpEntity();
-	}
-
-	/**
-	 * Disapprove an agent.
-	 *
-	 * @param id agent id
-	 * @return json message
-	 */
-	@RestAPI
-	@PreAuthorize("hasAnyRole('A')")
-	@RequestMapping(value = "/api/{id}", params = "action=disapprove", method = RequestMethod.PUT)
-	public HttpEntity<String> disapprove(@PathVariable("id") Long id) {
-		agentManagerService.approve(id, false);
-		return successJsonHttpEntity();
-	}
-
-	/**
-	 * Stop the given agent.
-	 *
-	 * @param id agent id
-	 * @return json message
-	 */
-	@RestAPI
-	@PreAuthorize("hasAnyRole('A')")
-	@RequestMapping(value = "/api/{id}", params = "action=stop", method = RequestMethod.PUT)
-	public HttpEntity<String> stop(@PathVariable("id") Long id) {
-		agentManagerService.stopAgent(id);
-		return successJsonHttpEntity();
-	}
-
-	/**
-	 * Stop the given agent.
-	 *
-	 * @param ids comma separated agent id list
-	 * @return json message
-	 */
-	@RestAPI
-	@PreAuthorize("hasAnyRole('A')")
-	@RequestMapping(value = "/api", params = "action=stop", method = RequestMethod.PUT)
-	public HttpEntity<String> stop(@RequestParam("ids") String ids) {
-		String[] split = StringUtils.split(ids, ",");
-		for (String each : split) {
-			stop(Long.parseLong(each));
-		}
-		return successJsonHttpEntity();
-	}
-
-	/**
-	 * Update the given agent.
-	 *
-	 * @param id agent id
-	 * @return json message
-	 */
-	@RestAPI
-	@PreAuthorize("hasAnyRole('A')")
-	@RequestMapping(value = "/api/{id}", params = "action=update", method = RequestMethod.PUT)
-	public HttpEntity<String> update(@PathVariable("id") Long id) {
-		agentManagerService.update(id);
-		return successJsonHttpEntity();
-	}
-
-	/**
-	 * Send update message to agent side
-	 *
-	 * @param ids comma separated agent id list
-	 * @return json message
-	 */
-	@RestAPI
-	@PreAuthorize("hasAnyRole('A')")
-	@RequestMapping(value = "/api", params = "action=update", method = RequestMethod.PUT)
-	public HttpEntity<String> update(@RequestParam("ids") String ids) {
-		String[] split = StringUtils.split(ids, ",");
-		for (String each : split) {
-			update(Long.parseLong(each));
-		}
-		return successJsonHttpEntity();
-	}
-
-	private List<Map<String, Object>> getAgentStatus(List<AgentInfo> agents) {
-		List<Map<String, Object>> statuses = newArrayList(agents.size());
-		for (AgentInfo each : agents) {
-			Map<String, Object> result = newHashMap();
-			result.put("id", each.getId());
-			result.put("port", each.getPort());
-			result.put("icon", each.getState().getCategory().getIconName());
-			result.put("state", each.getState());
-			statuses.add(result);
-		}
-		return statuses;
-	}
-	
-	/**
-	 * Get the number of available agents.
-	 * 
-	 * @param user The login user
-	 * @param targetRegion The name of target region
-	 * @return availableAgentCount Available agent count
-	 */
-	@RestAPI
-	@RequestMapping(value = {"/api/availableAgentCount"}, method = RequestMethod.GET)
-	@PreAuthorize("permitAll")
-	public HttpEntity<String> getAvailableAgentCount(User user,
-		@RequestParam(value = "targetRegion", required = true) String targetRegion) {
-		int availableAgentCount = agentManagerService.getReadyAgentCount(user, targetRegion);
-		HttpEntity<String> returnHttpEntity = toJsonHttpEntity(buildMap("availableAgentCount",
-			availableAgentCount));
-		return returnHttpEntity;
-	}
-	
 }

--- a/ngrinder-controller/src/main/java/org/ngrinder/operation/cotroller/LogMonitorController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/operation/cotroller/LogMonitorController.java
@@ -16,16 +16,17 @@ package org.ngrinder.operation.cotroller;
 import org.apache.commons.io.input.Tailer;
 import org.apache.commons.io.input.TailerListenerAdapter;
 import org.ngrinder.common.controller.BaseController;
-import org.springframework.http.HttpEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import java.io.File;
+import java.util.Map;
 
 import static org.ngrinder.common.util.CollectionUtils.buildMap;
 
@@ -136,9 +137,10 @@ public class LogMonitorController extends BaseController {
 	 *
 	 * @return log json
 	 */
+	@ResponseBody
 	@RequestMapping("/last")
-	public HttpEntity<String> getLast() {
-		return toJsonHttpEntity(buildMap("index", count, "modification", modification, "log", stringBuffer));
+	public Map<String, Object> getLast() {
+		return buildMap("index", count, "modification", modification, "log", stringBuffer);
 	}
 
 	/**
@@ -147,11 +149,12 @@ public class LogMonitorController extends BaseController {
 	 * @param verbose true if verbose mode
 	 * @return success message if successful
 	 */
+	@ResponseBody
 	@RequestMapping("/verbose")
-	public HttpEntity<String> enableVerbose(@RequestParam(value = "verbose", defaultValue = "false") Boolean verbose) {
+	public String enableVerbose(@RequestParam(value = "verbose", defaultValue = "false") Boolean verbose) {
 		getConfig().initLogger(verbose);
 		initTailer();
-		return toJsonHttpEntity(buildMap("success", true));
+		return returnSuccess();
 	}
 
 }

--- a/ngrinder-controller/src/main/java/org/ngrinder/operation/cotroller/SystemConfigController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/operation/cotroller/SystemConfigController.java
@@ -17,14 +17,13 @@ import org.ngrinder.common.controller.BaseController;
 import org.ngrinder.common.controller.RestAPI;
 import org.ngrinder.operation.service.SystemConfigService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 import static org.ngrinder.common.util.Preconditions.checkNotEmpty;
 
@@ -76,9 +75,10 @@ public class SystemConfigController extends BaseController {
 	 * @return system configuration
 	 */
 	@RestAPI
-	@RequestMapping(value = "/api", method = RequestMethod.GET)
-	public HttpEntity<String> getOne() {
-		return toJsonHttpEntity(systemConfigService.getOne());
+	@ResponseBody
+	@RequestMapping("/api")
+	public String getOne() {
+		return systemConfigService.getOne();
 	}
 
 	/**
@@ -88,10 +88,10 @@ public class SystemConfigController extends BaseController {
 	 * @return true if succeeded
 	 */
 	@RestAPI
+	@ResponseBody
 	@RequestMapping(value = "/api", method = RequestMethod.POST)
-	public HttpEntity<String> save(@RequestParam(required = true) final String content) {
-		systemConfigService.save(checkNotEmpty(content, "content should be " +
-				"passed as parameter"));
-		return successJsonHttpEntity();
+	public String save(@RequestParam final String content) {
+		systemConfigService.save(checkNotEmpty(content, "content should be passed as parameter"));
+		return returnSuccess();
 	}
 }

--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/controller/PerfTestApiController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/controller/PerfTestApiController.java
@@ -1,0 +1,477 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ngrinder.perftest.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.lang.mutable.MutableInt;
+import org.ngrinder.common.controller.RestAPI;
+import org.ngrinder.infra.config.Config;
+import org.ngrinder.infra.hazelcast.HazelcastService;
+import org.ngrinder.infra.logger.CoreLogger;
+import org.ngrinder.model.PerfTest;
+import org.ngrinder.model.Role;
+import org.ngrinder.model.Status;
+import org.ngrinder.model.User;
+import org.ngrinder.perftest.model.SamplingModel;
+import org.ngrinder.perftest.service.TagService;
+import org.ngrinder.script.model.FileCategory;
+import org.ngrinder.script.model.FileEntry;
+import org.ngrinder.script.service.FileEntryService;
+import org.ngrinder.user.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.apache.commons.lang.StringUtils.trimToEmpty;
+import static org.ngrinder.common.constant.CacheConstants.DIST_MAP_NAME_MONITORING;
+import static org.ngrinder.common.constant.CacheConstants.DIST_MAP_NAME_SAMPLING;
+import static org.ngrinder.common.util.CollectionUtils.buildMap;
+import static org.ngrinder.common.util.CollectionUtils.newHashMap;
+import static org.ngrinder.common.util.Preconditions.*;
+
+/**
+ * Performance Test Api Controller.
+ *
+ * @since 3.5.0
+ */
+@Profile("production")
+@RestController
+@RequestMapping("/perftest")
+public class PerfTestApiController extends PerfTestBaseController {
+
+	@Autowired
+	private FileEntryService fileEntryService;
+
+	@Autowired
+	private TagService tagService;
+
+	@Autowired
+	private UserService userService;
+
+	@Autowired
+	private HazelcastService hazelcastService;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	/**
+	 * Search tags based on the given query.
+	 *
+	 * @param user  user to search
+	 * @param query query string
+	 * @return found tag list in json
+	 */
+	@RequestMapping("/search_tag")
+	public List<String> searchTag(User user, @RequestParam(required = false) String query) {
+		List<String> allStrings = tagService.getAllTagStrings(user, query);
+		if (StringUtils.isNotBlank(query)) {
+			allStrings.add(query);
+		}
+		return allStrings;
+	}
+
+	/**
+	 * Leave the comment on the perf test.
+	 *
+	 * @param id          testId
+	 * @param user        user
+	 * @param testComment test comment
+	 * @param tagString   tagString
+	 * @return JSON
+	 */
+	@RequestMapping(value = "/{id}/leave_comment", method = RequestMethod.POST)
+	public String leaveComment(User user, @PathVariable("id") Long id, @RequestParam("testComment") String testComment,
+	                           @RequestParam(value = "tagString", required = false) String tagString) {
+		perfTestService.addCommentOn(user, id, testComment, tagString);
+		return returnSuccess();
+	}
+
+	private Long[] convertString2Long(String ids) {
+		String[] numbers = StringUtils.split(ids, ",");
+		Long[] id = new Long[numbers.length];
+		int i = 0;
+		for (String each : numbers) {
+			id[i++] = NumberUtils.toLong(each, 0);
+		}
+		return id;
+	}
+
+	/**
+	 * Delete the perf tests having given IDs.
+	 *
+	 * @param user user
+	 * @param ids  comma operated IDs
+	 * @return success json messages if succeeded.
+	 */
+	@RestAPI
+	@RequestMapping(value = "/api", method = RequestMethod.DELETE)
+	public String delete(User user, @RequestParam(value = "ids", defaultValue = "") String ids) {
+		for (String idStr : StringUtils.split(ids, ",")) {
+			perfTestService.delete(user, NumberUtils.toLong(idStr, 0));
+		}
+		return returnSuccess();
+	}
+
+	/**
+	 * Stop the perf tests having given IDs.
+	 *
+	 * @param user user
+	 * @param ids  comma separated perf test IDs
+	 * @return success json if succeeded.
+	 */
+	@RestAPI
+	@RequestMapping(value = "/api", params = "action=stop", method = RequestMethod.PUT)
+	public String stop(User user, @RequestParam(value = "ids", defaultValue = "") String ids) {
+		for (String idStr : StringUtils.split(ids, ",")) {
+			perfTestService.stop(user, NumberUtils.toLong(idStr, 0));
+		}
+		return returnSuccess();
+	}
+
+	/**
+	 * Get the running perf test info having the given id.
+	 *
+	 * @param user user
+	 * @param id   test id
+	 * @return JSON message	containing test,agent and monitor status.
+	 */
+	@RestAPI
+	@RequestMapping(value = "/{id}/api/sample")
+	public Map<String, Object> refreshTestRunning(User user, @PathVariable("id") long id) throws IOException {
+		PerfTest test = checkNotNull(getOneWithPermissionCheck(user, id, false), "given test should be exist : " + id);
+		Map<String, Object> map = newHashMap();
+
+		SamplingModel samplingModel = hazelcastService.get(DIST_MAP_NAME_SAMPLING, test.getId());
+		if (samplingModel != null) {
+			map.put("perf", objectMapper.readValue(samplingModel.getRunningSample(), HashMap.class));
+			map.put("agent", objectMapper.readValue(samplingModel.getAgentState(), HashMap.class));
+		}
+
+		String monitoringJson = hazelcastService.get(DIST_MAP_NAME_MONITORING, test.getId());
+		if (monitoringJson != null) {
+			map.put("monitor", objectMapper.readValue(monitoringJson, HashMap.class));
+		}
+
+		map.put("status", test.getStatus());
+		return map;
+	}
+
+
+	/**
+	 * Get the count of currently running perf test and the detailed progress info for the given perf test IDs.
+	 *
+	 * @param user user
+	 * @param ids  comma separated perf test list
+	 * @return JSON message containing perf test status
+	 */
+	@RestAPI
+	@RequestMapping("/api/status")
+	public Map<String, Object> getStatuses(User user, @RequestParam(value = "ids", defaultValue = "") String ids) {
+		List<PerfTest> perfTests = perfTestService.getAll(user, convertString2Long(ids));
+		return buildMap("perfTestInfo", perfTestService.getCurrentPerfTestStatistics(), "status", getStatus(perfTests));
+	}
+
+	/**
+	 * Get all available scripts in JSON format for the current factual user.
+	 *
+	 * @param user    user
+	 * @param ownerId owner id
+	 * @return JSON containing script's list.
+	 */
+	@RestAPI
+	@RequestMapping("/api/script")
+	public List<FileEntry> getScripts(User user, @RequestParam(value = "ownerId", required = false) String ownerId) {
+		if (StringUtils.isNotEmpty(ownerId)) {
+			user = userService.getOne(ownerId);
+		}
+		return newArrayList(fileEntryService.getAll(user).stream()
+			.filter(input -> input != null && input.getFileType().getFileCategory() == FileCategory.SCRIPT).collect(Collectors.toList()));
+	}
+
+	/**
+	 * Get resources and lib file list from the same folder with the given script path.
+	 *
+	 * @param user       user
+	 * @param scriptPath script path
+	 * @param ownerId    ownerId
+	 * @return json string representing resources and libs.
+	 */
+	@RequestMapping("/api/resource")
+	public Map<String, Object> getResources(User user, @RequestParam String scriptPath, @RequestParam(required = false) String ownerId) {
+		if (user.getRole() == Role.ADMIN && StringUtils.isNotBlank(ownerId)) {
+			user = userService.getOne(ownerId);
+		}
+		FileEntry fileEntry = fileEntryService.getOne(user, scriptPath);
+		String targetHosts = "";
+		List<String> fileStringList = newArrayList();
+		if (fileEntry != null) {
+			List<FileEntry> fileList = fileEntryService.getScriptHandler(fileEntry).getLibAndResourceEntries(user, fileEntry, -1L);
+			for (FileEntry each : fileList) {
+				fileStringList.add(each.getPath());
+			}
+			targetHosts = filterHostString(fileEntry.getProperties().get("targetHosts"));
+		}
+
+		return buildMap("targetHosts", trimToEmpty(targetHosts), "resources", fileStringList);
+	}
+
+
+	/**
+	 * Get the status of the given perf test.
+	 *
+	 * @param user user
+	 * @param id   perftest id
+	 * @return JSON message containing perf test status
+	 */
+	@RestAPI
+	@RequestMapping("/api/{id}/status")
+	public Map<String, Object> getStatus(User user, @PathVariable("id") Long id) {
+		List<PerfTest> perfTests = perfTestService.getAll(user, new Long[]{id});
+		return buildMap("status", getStatus(perfTests));
+	}
+
+	/**
+	 * Get the logs of the given perf test.
+	 *
+	 * @param user user
+	 * @param id   perftest id
+	 * @return JSON message containing log file names
+	 */
+	@RestAPI
+	@RequestMapping("/api/{id}/logs")
+	public List<String> getLogs(User user, @PathVariable("id") Long id) {
+		// Check permission
+		getOneWithPermissionCheck(user, id, false);
+		return perfTestService.getLogFiles(id);
+	}
+
+	/**
+	 * Get the detailed report graph data for the given perf test id.
+	 * This method returns the appropriate points based on the given imgWidth.
+	 *
+	 * @param id       test id
+	 * @param dataType which data
+	 * @param imgWidth imageWidth
+	 * @return json string.
+	 */
+	@SuppressWarnings("MVCPathVariableInspection")
+	@RestAPI
+	@RequestMapping({"/api/{id}/perf", "/api/{id}/graph"})
+	public Map<String, Object> getPerfGraph(@PathVariable("id") long id, @RequestParam String dataType,
+                                            @RequestParam(defaultValue = "false") boolean onlyTotal, @RequestParam int imgWidth) {
+		String[] dataTypes = checkNotEmpty(StringUtils.split(dataType, ","), "dataType argument should be provided");
+		return getPerfGraphData(id, dataTypes, onlyTotal, imgWidth);
+	}
+
+	/**
+	 * Get the monitor data of the target having the given IP.
+	 *
+	 * @param id       test Id
+	 * @param targetIP targetIP
+	 * @param imgWidth image width
+	 * @return json message
+	 */
+	@RestAPI
+	@RequestMapping("/api/{id}/monitor")
+	public Map<String, String> getMonitorGraph(@PathVariable("id") long id, @RequestParam("targetIP") String targetIP,
+                                               @RequestParam int imgWidth) {
+		return getMonitorGraphData(id, targetIP, imgWidth);
+	}
+
+	/**
+	 * Get the plugin monitor data of the target.
+	 *
+	 * @param id       test Id
+	 * @param plugin   monitor plugin category
+	 * @param kind     kind
+	 * @param imgWidth image width
+	 * @return json message
+	 */
+	@RestAPI
+	@RequestMapping("/api/{id}/plugin/{plugin}")
+	public Map<String, Object> getPluginGraph(@PathVariable("id") long id, @PathVariable("plugin") String plugin,
+                                              @RequestParam("kind") String kind, @RequestParam int imgWidth) {
+		return getReportPluginGraphData(id, plugin, kind, imgWidth);
+	}
+
+	/**
+	 * Get the last perf test details in the form of json.
+	 *
+	 * @param user user
+	 * @param page page
+	 * @param size size of retrieved perf test
+	 * @return json string
+	 */
+	@RestAPI
+	@RequestMapping({"/api/last", "/api", "/api/"})
+	public List<PerfTest> getAll(User user, @RequestParam(value = "page", defaultValue = "0") int page,
+                                 @RequestParam(value = "size", defaultValue = "1") int size) {
+		PageRequest pageRequest = PageRequest.of(page, size, new Sort(Direction.DESC, "id"));
+		Page<PerfTest> testList = perfTestService.getPagedAll(user, null, null, null, pageRequest);
+		return testList.getContent();
+	}
+
+	/**
+	 * Get the perf test detail in the form of json.
+	 *
+	 * @param user user
+	 * @param id   perftest id
+	 * @return json message containing test info.
+	 */
+	@RestAPI
+	@RequestMapping("/api/{id}")
+	public PerfTest getOne(User user, @PathVariable("id") Long id) {
+		return checkNotNull(getOneWithPermissionCheck(user, id, false), "PerfTest %s does not exists", id);
+	}
+
+	/**
+	 * Create the given perf test.
+	 *
+	 * @param user     user
+	 * @param perfTest perf test
+	 * @return json message containing test info.
+	 */
+	@RestAPI
+	@RequestMapping(value = {"/api/", "/api"}, method = RequestMethod.POST)
+	public PerfTest create(User user, PerfTest perfTest) {
+		checkNull(perfTest.getId(), "id should be null");
+		// Make the vuser count optional.
+		if (perfTest.getVuserPerAgent() == null && perfTest.getThreads() != null && perfTest.getProcesses() != null) {
+			perfTest.setVuserPerAgent(perfTest.getThreads() * perfTest.getProcesses());
+		}
+		validate(user, null, perfTest);
+		return perfTestService.save(user, perfTest);
+	}
+
+	/**
+	 * Delete the given perf test.
+	 *
+	 * @param user user
+	 * @param id   perf test id
+	 * @return json success message if succeeded
+	 */
+	@RestAPI
+	@RequestMapping(value = "/api/{id}", method = RequestMethod.DELETE)
+	public String delete(User user, @PathVariable("id") Long id) {
+		PerfTest perfTest = getOneWithPermissionCheck(user, id, false);
+		checkNotNull(perfTest, "no perftest for %s exits", id);
+		perfTestService.delete(user, id);
+		return returnSuccess();
+	}
+
+
+	/**
+	 * Update the given perf test.
+	 *
+	 * @param user     user
+	 * @param id       perf test id
+	 * @param perfTest perf test configuration changes
+	 * @return json message
+	 */
+	@RestAPI
+	@RequestMapping(value = "/api/{id}", method = RequestMethod.PUT)
+	public PerfTest update(User user, @PathVariable("id") Long id, PerfTest perfTest) {
+		PerfTest existingPerfTest = getOneWithPermissionCheck(user, id, false);
+		perfTest.setId(id);
+		validate(user, existingPerfTest, perfTest);
+		return perfTestService.save(user, perfTest);
+	}
+
+	/**
+	 * Stop the given perf test.
+	 *
+	 * @param user user
+	 * @param id   perf test id
+	 * @return json success message if succeeded
+	 */
+	@RestAPI
+	@RequestMapping(value = "/api/{id}", params = "action=stop", method = RequestMethod.PUT)
+	public String stop(User user, @PathVariable("id") Long id) {
+		perfTestService.stop(user, id);
+		return returnSuccess();
+	}
+
+
+	/**
+	 * Update the given perf test's status.
+	 *
+	 * @param user   user
+	 * @param id     perf test id
+	 * @param status Status to be moved to
+	 * @return json message
+	 */
+	@RestAPI
+	@RequestMapping(value = "/api/{id}", params = "action=status", method = RequestMethod.PUT)
+	public PerfTest updateStatus(User user, @PathVariable("id") Long id, Status status) {
+		PerfTest perfTest = getOneWithPermissionCheck(user, id, false);
+		checkNotNull(perfTest, "no perftest for %s exits", id).setStatus(status);
+		validate(user, null, perfTest);
+		return perfTestService.save(user, perfTest);
+	}
+
+	/**
+	 * Clone and start the given perf test.
+	 *
+	 * @param user     user
+	 * @param id       perf test id to be cloned
+	 * @param perftest option to override while cloning.
+	 * @return json string
+	 */
+	@RestAPI
+	@RequestMapping(value = {"/api/{id}/clone_and_start", /* for backward compatibility */ "/api/{id}/cloneAndStart"})
+	public PerfTest cloneAndStart(User user, @PathVariable("id") Long id, PerfTest perftest) {
+		PerfTest test = getOneWithPermissionCheck(user, id, false);
+		checkNotNull(test, "no perftest for %s exits", id);
+		PerfTest newOne = test.cloneTo(new PerfTest());
+		newOne.setStatus(Status.READY);
+		if (perftest != null) {
+			if (perftest.getScheduledTime() != null) {
+				newOne.setScheduledTime(perftest.getScheduledTime());
+			}
+			if (perftest.getScriptRevision() != null) {
+				newOne.setScriptRevision(perftest.getScriptRevision());
+			}
+
+			if (perftest.getAgentCount() != null) {
+				newOne.setAgentCount(perftest.getAgentCount());
+			}
+		}
+		if (newOne.getAgentCount() == null) {
+			newOne.setAgentCount(0);
+		}
+		Map<String, MutableInt> agentCountMap = agentManagerService.getAvailableAgentCountMap(user);
+		MutableInt agentCountObj = agentCountMap.get(isClustered() ? test.getRegion() : Config.NONE_REGION);
+		checkNotNull(agentCountObj, "test region should be within current region list");
+		int agentMaxCount = agentCountObj.intValue();
+		checkArgument(newOne.getAgentCount() != 0, "test agent should not be %s", agentMaxCount);
+		checkArgument(newOne.getAgentCount() <= agentMaxCount, "test agent should be equal to or less than %s",
+				agentMaxCount);
+		PerfTest savePerfTest = perfTestService.save(user, newOne);
+		CoreLogger.LOGGER.info("test {} is created through web api by {}", savePerfTest.getId(), user.getUserId());
+		return savePerfTest;
+	}
+}

--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/controller/PerfTestBaseController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/controller/PerfTestBaseController.java
@@ -1,0 +1,249 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ngrinder.perftest.controller;
+
+import net.grinder.util.Pair;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.mutable.MutableInt;
+import org.ngrinder.agent.service.AgentManagerService;
+import org.ngrinder.common.constant.ControllerConstants;
+import org.ngrinder.common.constants.GrinderConstants;
+import org.ngrinder.common.controller.BaseController;
+import org.ngrinder.common.util.DateUtils;
+import org.ngrinder.infra.config.Config;
+import org.ngrinder.model.*;
+import org.ngrinder.perftest.service.AgentManager;
+import org.ngrinder.perftest.service.PerfTestService;
+import org.python.google.common.collect.Maps;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.ui.ModelMap;
+
+import java.util.*;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.ngrinder.common.util.CollectionUtils.newHashMap;
+import static org.ngrinder.common.util.ExceptionUtils.processException;
+import static org.ngrinder.common.util.Preconditions.*;
+
+
+/**
+ * Perftest controller base containing common used methods.
+ *
+ * @since 3.5.0
+ */
+public class PerfTestBaseController extends BaseController {
+
+	@Autowired
+	protected PerfTestService perfTestService;
+
+	@Autowired
+	protected AgentManager agentManager;
+
+	@Autowired
+	protected AgentManagerService agentManagerService;
+
+	/**
+	 * Add the various default configuration values on the model.
+	 *
+	 * @param model model to which put the default values
+	 */
+	public void addDefaultAttributeOnModel(ModelMap model) {
+		model.addAttribute(PARAM_AVAILABLE_RAMP_UP_TYPE, RampUp.values());
+		model.addAttribute(PARAM_MAX_VUSER_PER_AGENT, agentManager.getMaxVuserPerAgent());
+		model.addAttribute(PARAM_MAX_RUN_COUNT, agentManager.getMaxRunCount());
+		if (getConfig().isSecurityEnabled()) {
+			model.addAttribute(PARAM_SECURITY_LEVEL, getConfig().getSecurityLevel());
+		}
+		model.addAttribute(PARAM_MAX_RUN_HOUR, agentManager.getMaxRunHour());
+		model.addAttribute(PARAM_SAFE_FILE_DISTRIBUTION,
+			getConfig().getControllerProperties().getPropertyBoolean(ControllerConstants.PROP_CONTROLLER_SAFE_DIST));
+		String timeZone = getCurrentUser().getTimeZone();
+		int offset;
+		if (StringUtils.isNotBlank(timeZone)) {
+			offset = TimeZone.getTimeZone(timeZone).getOffset(System.currentTimeMillis());
+		} else {
+			offset = TimeZone.getDefault().getOffset(System.currentTimeMillis());
+		}
+		model.addAttribute(PARAM_TIMEZONE_OFFSET, offset);
+	}
+
+	protected List<Map<String, Object>> getStatus(List<PerfTest> perfTests) {
+		List<Map<String, Object>> statuses = newArrayList();
+		for (PerfTest each : perfTests) {
+			Map<String, Object> result = newHashMap();
+			result.put("id", each.getId());
+			result.put("status_id", each.getStatus());
+			result.put("status_type", each.getStatus());
+			result.put("name", getMessages(each.getStatus().getSpringMessageKey()));
+			result.put("icon", each.getStatus().getIconName());
+			result.put("message",
+				StringUtils.replace(each.getProgressMessage() + "\n<b>" + each.getLastProgressMessage() + "</b>\n"
+					+ each.getLastModifiedDateToStr(), "\n", "<br/>"));
+			result.put("deletable", each.getStatus().isDeletable());
+			result.put("stoppable", each.getStatus().isStoppable());
+			result.put("reportable", each.getStatus().isReportable());
+			statuses.add(result);
+		}
+		return statuses;
+	}
+
+	/**
+	 * Filter out please_modify_this.com from hosts string.
+	 *
+	 * @param originalString original string
+	 * @return filtered string
+	 */
+	protected String filterHostString(String originalString) {
+		List<String> hosts = newArrayList();
+		for (String each : StringUtils.split(StringUtils.trimToEmpty(originalString), ",")) {
+			if (!each.contains("please_modify_this.com")) {
+				hosts.add(each);
+			}
+		}
+		return StringUtils.join(hosts, ",");
+	}
+
+
+	protected Map<String, String> getMonitorGraphData(long id, String targetIP, int imgWidth) {
+		int interval = perfTestService.getMonitorGraphInterval(id, targetIP, imgWidth);
+		Map<String, String> sysMonitorMap = perfTestService.getMonitorGraph(id, targetIP, interval);
+		PerfTest perfTest = perfTestService.getOne(id);
+		sysMonitorMap.put("interval", String.valueOf(interval * (perfTest != null ? perfTest.getSamplingInterval() : 1)));
+		return sysMonitorMap;
+	}
+
+	protected Map<String, Object> getReportPluginGraphData(long id, String plugin, String kind, int imgWidth) {
+		int interval = perfTestService.getReportPluginGraphInterval(id, plugin, kind, imgWidth);
+		Map<String, Object> pluginMonitorData = perfTestService.getReportPluginGraph(id, plugin, kind, interval);
+		final PerfTest perfTest = perfTestService.getOne(id);
+		int samplingInterval = 3;
+		if (perfTest != null) {
+			samplingInterval = perfTest.getSamplingInterval();
+		}
+		pluginMonitorData.put("interval", interval * samplingInterval);
+		return pluginMonitorData;
+	}
+
+	protected PerfTest getOneWithPermissionCheck(User user, Long id, boolean withTag) {
+		PerfTest perfTest = withTag ? perfTestService.getOneWithTag(id) : perfTestService.getOne(id);
+		if (user.getRole().equals(Role.ADMIN) || user.getRole().equals(Role.SUPER_USER)) {
+			return perfTest;
+		}
+		if (perfTest != null && !user.equals(perfTest.getCreatedUser())) {
+			throw processException("User " + user.getUserId() + " has no right on PerfTest " + id);
+		}
+		return perfTest;
+	}
+
+	protected Map<String, Object> getPerfGraphData(Long id, String[] dataTypes, boolean onlyTotal, int imgWidth) {
+		final PerfTest test = perfTestService.getOne(id);
+		int interval = perfTestService.getReportDataInterval(id, dataTypes[0], imgWidth);
+		Map<String, Object> resultMap = Maps.newHashMap();
+		for (String each : dataTypes) {
+			Pair<ArrayList<String>, ArrayList<String>> tpsResult = perfTestService.getReportData(id, each, onlyTotal, interval);
+			Map<String, Object> dataMap = Maps.newHashMap();
+			dataMap.put("labels", tpsResult.getFirst());
+			dataMap.put("data", tpsResult.getSecond());
+			resultMap.put(StringUtils.replaceChars(each, "()", ""), dataMap);
+		}
+		resultMap.put(PARAM_TEST_CHART_INTERVAL, interval * test.getSamplingInterval());
+		return resultMap;
+	}
+
+	@SuppressWarnings("ConstantConditions")
+	protected void validate(User user, PerfTest oldOne, PerfTest newOne) {
+		if (oldOne == null) {
+			oldOne = new PerfTest();
+			oldOne.init();
+		}
+		newOne = oldOne.merge(newOne);
+		checkNotEmpty(newOne.getTestName(), "testName should be provided");
+		checkArgument(newOne.getStatus().equals(Status.READY) || newOne.getStatus().equals(Status.SAVED),
+			"status only allows SAVE or READY");
+		if (newOne.isThresholdRunCount()) {
+			final Integer runCount = newOne.getRunCount();
+			checkArgument(runCount > 0 && runCount <= agentManager
+					.getMaxRunCount(),
+				"runCount should be equal to or less than %s", agentManager.getMaxRunCount());
+		} else {
+			final Long duration = newOne.getDuration();
+			checkArgument(duration > 0 && duration <= (((long) agentManager.getMaxRunHour()) *
+					3600000L),
+				"duration should be equal to or less than %s", agentManager.getMaxRunHour());
+		}
+		Map<String, MutableInt> agentCountMap = agentManagerService.getAvailableAgentCountMap(user);
+		MutableInt agentCountObj = agentCountMap.get(isClustered() ? newOne.getRegion() : Config.NONE_REGION);
+		checkNotNull(agentCountObj, "region should be within current region list");
+		int agentMaxCount = agentCountObj.intValue();
+		checkArgument(newOne.getAgentCount() <= agentMaxCount, "test agent should be equal to or less than %s",
+			agentMaxCount);
+		if (newOne.getStatus().equals(Status.READY)) {
+			checkArgument(newOne.getAgentCount() >= 1, "agentCount should be more than 1 when it's READY status.");
+		}
+
+		checkArgument(newOne.getVuserPerAgent() <= agentManager.getMaxVuserPerAgent(),
+			"vuserPerAgent should be equal to or less than %s", agentManager.getMaxVuserPerAgent());
+		if (getConfig().isSecurityEnabled() && GrinderConstants.GRINDER_SECURITY_LEVEL_NORMAL.equals(getConfig().getSecurityLevel())) {
+			checkArgument(StringUtils.isNotEmpty(newOne.getTargetHosts()),
+				"targetHosts should be provided when security mode is enabled");
+		}
+		if (newOne.getStatus() != Status.SAVED) {
+			checkArgument(StringUtils.isNotBlank(newOne.getScriptName()), "scriptName should be provided.");
+		}
+		checkArgument(newOne.getVuserPerAgent() == newOne.getProcesses() * newOne.getThreads(),
+			"vuserPerAgent should be equal to (processes * threads)");
+	}
+
+	protected ArrayList<String> getRegions(Map<String, MutableInt> agentCountMap) {
+		ArrayList<String> regions = new ArrayList<>(agentCountMap.keySet());
+		Collections.sort(regions);
+		return regions;
+	}
+
+	protected void annotateDateMarker(Page<PerfTest> tests) {
+		TimeZone userTZ = TimeZone.getTimeZone(getCurrentUser().getTimeZone());
+		Calendar userToday = Calendar.getInstance(userTZ);
+		Calendar userYesterday = Calendar.getInstance(userTZ);
+		userYesterday.add(Calendar.DATE, -1);
+		for (PerfTest test : tests) {
+			Calendar localedModified = Calendar.getInstance(userTZ);
+			localedModified.setTime(DateUtils.convertToUserDate(getCurrentUser().getTimeZone(),
+				test.getLastModifiedDate()));
+			if (org.apache.commons.lang.time.DateUtils.isSameDay(userToday, localedModified)) {
+				test.setDateString("today");
+			} else if (org.apache.commons.lang.time.DateUtils.isSameDay(userYesterday, localedModified)) {
+				test.setDateString("yesterday");
+			} else {
+				test.setDateString("earlier");
+			}
+		}
+	}
+
+	/**
+	 * Create a new test from quick start mode.
+	 *
+	 * @param user       user
+	 * @param testName   test name
+	 * @param targetHost target host
+	 * @return test    {@link PerfTest}
+	 */
+	protected PerfTest createPerfTestFromQuickStart(User user, String testName, String targetHost) {
+		PerfTest test = new PerfTest(user);
+		test.init();
+		test.setTestName(testName);
+		test.setTargetHosts(targetHost);
+		return test;
+	}
+}

--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/controller/PerfTestController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/controller/PerfTestController.java
@@ -13,38 +13,22 @@
  */
 package org.ngrinder.perftest.controller;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import net.grinder.util.LogCompressUtils;
-import net.grinder.util.Pair;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.lang.mutable.MutableInt;
-import org.ngrinder.agent.service.AgentManagerService;
-import org.ngrinder.common.constant.ControllerConstants;
-import org.ngrinder.common.constants.GrinderConstants;
-import org.ngrinder.common.controller.BaseController;
-import org.ngrinder.common.controller.RestAPI;
-import org.ngrinder.common.util.DateUtils;
 import org.ngrinder.common.util.FileDownloadUtils;
-import org.ngrinder.infra.config.Config;
-import org.ngrinder.infra.hazelcast.HazelcastService;
 import org.ngrinder.infra.logger.CoreLogger;
 import org.ngrinder.infra.spring.RemainedPath;
-import org.ngrinder.model.*;
-import org.ngrinder.perftest.model.SamplingModel;
-import org.ngrinder.perftest.service.AgentManager;
-import org.ngrinder.perftest.service.PerfTestService;
+import org.ngrinder.model.PerfTest;
+import org.ngrinder.model.Status;
+import org.ngrinder.model.User;
 import org.ngrinder.perftest.service.TagService;
 import org.ngrinder.region.service.RegionService;
 import org.ngrinder.script.handler.ScriptHandlerFactory;
-import org.ngrinder.script.model.FileCategory;
 import org.ngrinder.script.model.FileEntry;
 import org.ngrinder.script.service.FileEntryService;
-import org.ngrinder.user.service.UserService;
-import org.python.google.common.collect.Maps;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.Page;
@@ -53,29 +37,22 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.HttpEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 
-import javax.annotation.Nullable;
-import javax.annotation.PostConstruct;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.FileInputStream;
 import java.net.URL;
-import java.util.*;
+import java.util.Map;
 
-import static com.google.common.collect.Iterables.filter;
-import static com.google.common.collect.Lists.newArrayList;
-import static org.apache.commons.lang.StringUtils.trimToEmpty;
-import static org.ngrinder.common.constant.CacheConstants.DIST_MAP_NAME_MONITORING;
-import static org.ngrinder.common.constant.CacheConstants.DIST_MAP_NAME_SAMPLING;
-import static org.ngrinder.common.util.CollectionUtils.buildMap;
-import static org.ngrinder.common.util.CollectionUtils.newHashMap;
-import static org.ngrinder.common.util.ExceptionUtils.processException;
-import static org.ngrinder.common.util.Preconditions.*;
+import static org.ngrinder.common.util.Preconditions.checkState;
+import static org.ngrinder.common.util.Preconditions.checkValidURL;
 
 /**
  * Performance Test Controller.
@@ -83,23 +60,13 @@ import static org.ngrinder.common.util.Preconditions.*;
  * @author Mavlarn
  * @author JunHo Yoon
  */
-@SuppressWarnings("SpringJavaAutowiringInspection")
 @Profile("production")
 @Controller
 @RequestMapping("/perftest")
-public class PerfTestController extends BaseController {
-
-	@Autowired
-	private PerfTestService perfTestService;
+public class PerfTestController extends PerfTestBaseController {
 
 	@Autowired
 	private FileEntryService fileEntryService;
-
-	@Autowired
-	private AgentManager agentManager;
-
-	@Autowired
-	private AgentManagerService agentManagerService;
 
 	@Autowired
 	private TagService tagService;
@@ -108,23 +75,7 @@ public class PerfTestController extends BaseController {
 	private ScriptHandlerFactory scriptHandlerFactory;
 
 	@Autowired
-	private UserService userService;
-
-	@Autowired
 	private RegionService regionService;
-
-	@Autowired
-	private HazelcastService hazelcastService;
-
-	private Gson gson;
-
-	/**
-	 * Initialize.
-	 */
-	@PostConstruct
-	public void init() {
-		gson = new GsonBuilder().registerTypeAdapter(FileEntry.class, new FileEntry.FileEntrySerializer()).create();
-	}
 
 	/**
 	 * Get the perf test lists.
@@ -157,25 +108,6 @@ public class PerfTestController extends BaseController {
 		model.addAttribute("query", query);
 		putPageIntoModelMap(model, pageable);
 		return "perftest/list";
-	}
-
-	private void annotateDateMarker(Page<PerfTest> tests) {
-		TimeZone userTZ = TimeZone.getTimeZone(getCurrentUser().getTimeZone());
-		Calendar userToday = Calendar.getInstance(userTZ);
-		Calendar userYesterday = Calendar.getInstance(userTZ);
-		userYesterday.add(Calendar.DATE, -1);
-		for (PerfTest test : tests) {
-			Calendar localedModified = Calendar.getInstance(userTZ);
-			localedModified.setTime(DateUtils.convertToUserDate(getCurrentUser().getTimeZone(),
-					test.getLastModifiedDate()));
-			if (org.apache.commons.lang.time.DateUtils.isSameDay(userToday, localedModified)) {
-				test.setDateString("today");
-			} else if (org.apache.commons.lang.time.DateUtils.isSameDay(userYesterday, localedModified)) {
-				test.setDateString("yesterday");
-			} else {
-				test.setDateString("earlier");
-			}
-		}
 	}
 
 	/**
@@ -223,54 +155,6 @@ public class PerfTestController extends BaseController {
 		return "perftest/detail";
 	}
 
-	private ArrayList<String> getRegions(Map<String, MutableInt> agentCountMap) {
-		ArrayList<String> regions = new ArrayList<String>(agentCountMap.keySet());
-		Collections.sort(regions);
-		return regions;
-	}
-
-
-	/**
-	 * Search tags based on the given query.
-	 *
-	 * @param user  user to search
-	 * @param query query string
-	 * @return found tag list in json
-	 */
-	@RequestMapping("/search_tag")
-	public HttpEntity<String> searchTag(User user, @RequestParam(required = false) String query) {
-		List<String> allStrings = tagService.getAllTagStrings(user, query);
-		if (StringUtils.isNotBlank(query)) {
-			allStrings.add(query);
-		}
-		return toJsonHttpEntity(allStrings);
-	}
-
-	/**
-	 * Add the various default configuration values on the model.
-	 *
-	 * @param model model to which put the default values
-	 */
-	public void addDefaultAttributeOnModel(ModelMap model) {
-		model.addAttribute(PARAM_AVAILABLE_RAMP_UP_TYPE, RampUp.values());
-		model.addAttribute(PARAM_MAX_VUSER_PER_AGENT, agentManager.getMaxVuserPerAgent());
-		model.addAttribute(PARAM_MAX_RUN_COUNT, agentManager.getMaxRunCount());
-		if (getConfig().isSecurityEnabled()) {
-			model.addAttribute(PARAM_SECURITY_LEVEL, getConfig().getSecurityLevel());
-		}
-		model.addAttribute(PARAM_MAX_RUN_HOUR, agentManager.getMaxRunHour());
-		model.addAttribute(PARAM_SAFE_FILE_DISTRIBUTION,
-				getConfig().getControllerProperties().getPropertyBoolean(ControllerConstants.PROP_CONTROLLER_SAFE_DIST));
-		String timeZone = getCurrentUser().getTimeZone();
-		int offset;
-		if (StringUtils.isNotBlank(timeZone)) {
-			offset = TimeZone.getTimeZone(timeZone).getOffset(System.currentTimeMillis());
-		} else {
-			offset = TimeZone.getDefault().getOffset(System.currentTimeMillis());
-		}
-		model.addAttribute(PARAM_TIMEZONE_OFFSET, offset);
-	}
-
 	/**
 	 * Get the perf test creation form for quickStart.
 	 *
@@ -300,22 +184,6 @@ public class PerfTestController extends BaseController {
 	}
 
 	/**
-	 * Create a new test from quick start mode.
-	 *
-	 * @param user       user
-	 * @param testName   test name
-	 * @param targetHost target host
-	 * @return test    {@link PerfTest}
-	 */
-	private PerfTest createPerfTestFromQuickStart(User user, String testName, String targetHost) {
-		PerfTest test = new PerfTest(user);
-		test.init();
-		test.setTestName(testName);
-		test.setTargetHosts(targetHost);
-		return test;
-	}
-
-	/**
 	 * Create a new test or cloneTo a current test.
 	 *
 	 * @param user     user
@@ -341,164 +209,6 @@ public class PerfTestController extends BaseController {
 			return "redirect:/perftest/" + perfTest.getId();
 		}
 	}
-
-	@SuppressWarnings("ConstantConditions")
-	private void validate(User user, PerfTest oldOne, PerfTest newOne) {
-		if (oldOne == null) {
-			oldOne = new PerfTest();
-			oldOne.init();
-		}
-		newOne = oldOne.merge(newOne);
-		checkNotEmpty(newOne.getTestName(), "testName should be provided");
-		checkArgument(newOne.getStatus().equals(Status.READY) || newOne.getStatus().equals(Status.SAVED),
-				"status only allows SAVE or READY");
-		if (newOne.isThresholdRunCount()) {
-			final Integer runCount = newOne.getRunCount();
-			checkArgument(runCount > 0 && runCount <= agentManager
-					.getMaxRunCount(),
-					"runCount should be equal to or less than %s", agentManager.getMaxRunCount());
-		} else {
-			final Long duration = newOne.getDuration();
-			checkArgument(duration > 0 && duration <= (((long) agentManager.getMaxRunHour()) *
-					3600000L),
-					"duration should be equal to or less than %s", agentManager.getMaxRunHour());
-		}
-		Map<String, MutableInt> agentCountMap = agentManagerService.getAvailableAgentCountMap(user);
-		MutableInt agentCountObj = agentCountMap.get(isClustered() ? newOne.getRegion() : Config.NONE_REGION);
-		checkNotNull(agentCountObj, "region should be within current region list");
-		int agentMaxCount = agentCountObj.intValue();
-		checkArgument(newOne.getAgentCount() <= agentMaxCount, "test agent should be equal to or less than %s",
-				agentMaxCount);
-		if (newOne.getStatus().equals(Status.READY)) {
-			checkArgument(newOne.getAgentCount() >= 1, "agentCount should be more than 1 when it's READY status.");
-		}
-
-		checkArgument(newOne.getVuserPerAgent() <= agentManager.getMaxVuserPerAgent(),
-				"vuserPerAgent should be equal to or less than %s", agentManager.getMaxVuserPerAgent());
-		if (getConfig().isSecurityEnabled() && GrinderConstants.GRINDER_SECURITY_LEVEL_NORMAL.equals(getConfig().getSecurityLevel())) {
-			checkArgument(StringUtils.isNotEmpty(newOne.getTargetHosts()),
-					"targetHosts should be provided when security mode is enabled");
-		}
-		if (newOne.getStatus() != Status.SAVED) {
-			checkArgument(StringUtils.isNotBlank(newOne.getScriptName()), "scriptName should be provided.");
-		}
-		checkArgument(newOne.getVuserPerAgent() == newOne.getProcesses() * newOne.getThreads(),
-				"vuserPerAgent should be equal to (processes * threads)");
-	}
-
-	/**
-	 * Leave the comment on the perf test.
-	 *
-	 * @param id          testId
-	 * @param user        user
-	 * @param testComment test comment
-	 * @param tagString   tagString
-	 * @return JSON
-	 */
-	@RequestMapping(value = "/{id}/leave_comment", method = RequestMethod.POST)
-	@ResponseBody
-	public String leaveComment(User user, @PathVariable("id") Long id, @RequestParam("testComment") String testComment,
-	                           @RequestParam(value = "tagString", required = false) String tagString) {
-		perfTestService.addCommentOn(user, id, testComment, tagString);
-		return returnSuccess();
-	}
-
-
-	private Long[] convertString2Long(String ids) {
-		String[] numbers = StringUtils.split(ids, ",");
-		Long[] id = new Long[numbers.length];
-		int i = 0;
-		for (String each : numbers) {
-			id[i++] = NumberUtils.toLong(each, 0);
-		}
-		return id;
-	}
-
-	private List<Map<String, Object>> getStatus(List<PerfTest> perfTests) {
-		List<Map<String, Object>> statuses = newArrayList();
-		for (PerfTest each : perfTests) {
-			Map<String, Object> result = newHashMap();
-			result.put("id", each.getId());
-			result.put("status_id", each.getStatus());
-			result.put("status_type", each.getStatus());
-			result.put("name", getMessages(each.getStatus().getSpringMessageKey()));
-			result.put("icon", each.getStatus().getIconName());
-			result.put("message",
-					StringUtils.replace(each.getProgressMessage() + "\n<b>" + each.getLastProgressMessage() + "</b>\n"
-							+ each.getLastModifiedDateToStr(), "\n", "<br/>"));
-			result.put("deletable", each.getStatus().isDeletable());
-			result.put("stoppable", each.getStatus().isStoppable());
-			result.put("reportable", each.getStatus().isReportable());
-			statuses.add(result);
-		}
-		return statuses;
-	}
-
-
-	/**
-	 * Delete the perf tests having given IDs.
-	 *
-	 * @param user user
-	 * @param ids  comma operated IDs
-	 * @return success json messages if succeeded.
-	 */
-	@RestAPI
-	@RequestMapping(value = "/api", method = RequestMethod.DELETE)
-	public HttpEntity<String> delete(User user, @RequestParam(value = "ids", defaultValue = "") String ids) {
-		for (String idStr : StringUtils.split(ids, ",")) {
-			perfTestService.delete(user, NumberUtils.toLong(idStr, 0));
-		}
-		return successJsonHttpEntity();
-	}
-
-	/**
-	 * Stop the perf tests having given IDs.
-	 *
-	 * @param user user
-	 * @param ids  comma separated perf test IDs
-	 * @return success json if succeeded.
-	 */
-	@RestAPI
-	@RequestMapping(value = "/api", params = "action=stop", method = RequestMethod.PUT)
-	public HttpEntity<String> stop(User user, @RequestParam(value = "ids", defaultValue = "") String ids) {
-		for (String idStr : StringUtils.split(ids, ",")) {
-			perfTestService.stop(user, NumberUtils.toLong(idStr, 0));
-		}
-		return successJsonHttpEntity();
-	}
-
-	/**
-	 * Filter out please_modify_this.com from hosts string.
-	 *
-	 * @param originalString original string
-	 * @return filtered string
-	 */
-	private String filterHostString(String originalString) {
-		List<String> hosts = newArrayList();
-		for (String each : StringUtils.split(StringUtils.trimToEmpty(originalString), ",")) {
-			if (!each.contains("please_modify_this.com")) {
-				hosts.add(each);
-			}
-		}
-		return StringUtils.join(hosts, ",");
-	}
-
-
-	private Map<String, Object> getPerfGraphData(Long id, String[] dataTypes, boolean onlyTotal, int imgWidth) {
-		final PerfTest test = perfTestService.getOne(id);
-		int interval = perfTestService.getReportDataInterval(id, dataTypes[0], imgWidth);
-		Map<String, Object> resultMap = Maps.newHashMap();
-		for (String each : dataTypes) {
-			Pair<ArrayList<String>, ArrayList<String>> tpsResult = perfTestService.getReportData(id, each, onlyTotal, interval);
-			Map<String, Object> dataMap = Maps.newHashMap();
-			dataMap.put("labels", tpsResult.getFirst());
-			dataMap.put("data", tpsResult.getSecond());
-			resultMap.put(StringUtils.replaceChars(each, "()", ""), dataMap);
-		}
-		resultMap.put(PARAM_TEST_CHART_INTERVAL, interval * test.getSamplingInterval());
-		return resultMap;
-	}
-
 
 	/**
 	 * Get the running division in perftest configuration page.
@@ -604,34 +314,6 @@ public class PerfTestController extends BaseController {
 	}
 
 	/**
-	 * Get the running perf test info having the given id.
-	 *
-	 * @param user user
-	 * @param id   test id
-	 * @return JSON message	containing test,agent and monitor status.
-	 */
-	@RequestMapping(value = "/{id}/api/sample")
-	@RestAPI
-	public HttpEntity<String> refreshTestRunning(User user, @PathVariable("id") long id) {
-		PerfTest test = checkNotNull(getOneWithPermissionCheck(user, id, false), "given test should be exist : " + id);
-		Map<String, Object> map = newHashMap();
-
-		SamplingModel samplingModel = hazelcastService.get(DIST_MAP_NAME_SAMPLING, test.getId());
-		if (samplingModel != null) {
-			map.put("perf", gson.fromJson(samplingModel.getRunningSample(), HashMap.class));
-			map.put("agent", gson.fromJson(samplingModel.getAgentState(), HashMap.class));
-		}
-
-		String monitoringJson = hazelcastService.get(DIST_MAP_NAME_MONITORING, test.getId());
-		if (monitoringJson != null) {
-			map.put("monitor", gson.fromJson(monitoringJson, HashMap.class));
-		}
-
-		map.put("status", test.getStatus());
-		return toJsonHttpEntity(map);
-	}
-
-	/**
 	 * Get the detailed perf test report.
 	 *
 	 * @param model model
@@ -690,350 +372,4 @@ public class PerfTestController extends BaseController {
 		modelMap.addAttribute("kind", kind);
 		return "perftest/detail_report/plugin";
 	}
-
-
-	private PerfTest getOneWithPermissionCheck(User user, Long id, boolean withTag) {
-		PerfTest perfTest = withTag ? perfTestService.getOneWithTag(id) : perfTestService.getOne(id);
-		if (user.getRole().equals(Role.ADMIN) || user.getRole().equals(Role.SUPER_USER)) {
-			return perfTest;
-		}
-		if (perfTest != null && !user.equals(perfTest.getCreatedUser())) {
-			throw processException("User " + user.getUserId() + " has no right on PerfTest " + id);
-		}
-		return perfTest;
-	}
-
-
-	private Map<String, String> getMonitorGraphData(long id, String targetIP, int imgWidth) {
-		int interval = perfTestService.getMonitorGraphInterval(id, targetIP, imgWidth);
-		Map<String, String> sysMonitorMap = perfTestService.getMonitorGraph(id, targetIP, interval);
-		PerfTest perfTest = perfTestService.getOne(id);
-		sysMonitorMap.put("interval", String.valueOf(interval * (perfTest != null ? perfTest.getSamplingInterval() : 1)));
-		return sysMonitorMap;
-	}
-
-
-	/**
-	 * Get the count of currently running perf test and the detailed progress info for the given perf test IDs.
-	 *
-	 * @param user user
-	 * @param ids  comma separated perf test list
-	 * @return JSON message containing perf test status
-	 */
-	@RestAPI
-	@RequestMapping("/api/status")
-	public HttpEntity<String> getStatuses(User user, @RequestParam(value = "ids", defaultValue = "") String ids) {
-		List<PerfTest> perfTests = perfTestService.getAll(user, convertString2Long(ids));
-		return toJsonHttpEntity(buildMap("perfTestInfo", perfTestService.getCurrentPerfTestStatistics(), "status",
-				getStatus(perfTests)));
-	}
-
-	/**
-	 * Get all available scripts in JSON format for the current factual user.
-	 *
-	 * @param user    user
-	 * @param ownerId owner id
-	 * @return JSON containing script's list.
-	 */
-	@RestAPI
-	@RequestMapping("/api/script")
-	public HttpEntity<String> getScripts(User user, @RequestParam(value = "ownerId", required = false) String ownerId) {
-		if (StringUtils.isNotEmpty(ownerId)) {
-			user = userService.getOne(ownerId);
-		}
-		List<FileEntry> scripts = newArrayList(filter(fileEntryService.getAll(user),
-				new com.google.common.base.Predicate<FileEntry>() {
-					@Override
-					public boolean apply(@Nullable FileEntry input) {
-						return input != null && input.getFileType().getFileCategory() == FileCategory.SCRIPT;
-					}
-				}));
-		return toJsonHttpEntity(scripts, gson);
-	}
-
-
-	/**
-	 * Get resources and lib file list from the same folder with the given script path.
-	 *
-	 * @param user       user
-	 * @param scriptPath script path
-	 * @param ownerId    ownerId
-	 * @return json string representing resources and libs.
-	 */
-	@RequestMapping("/api/resource")
-	public HttpEntity<String> getResources(User user, @RequestParam String scriptPath,
-	                                       @RequestParam(required = false) String ownerId) {
-		if (user.getRole() == Role.ADMIN && StringUtils.isNotBlank(ownerId)) {
-			user = userService.getOne(ownerId);
-		}
-		FileEntry fileEntry = fileEntryService.getOne(user, scriptPath);
-		String targetHosts = "";
-		List<String> fileStringList = newArrayList();
-		if (fileEntry != null) {
-			List<FileEntry> fileList = fileEntryService.getScriptHandler(fileEntry).getLibAndResourceEntries(user, fileEntry, -1L);
-			for (FileEntry each : fileList) {
-				fileStringList.add(each.getPath());
-			}
-			targetHosts = filterHostString(fileEntry.getProperties().get("targetHosts"));
-		}
-
-		return toJsonHttpEntity(buildMap("targetHosts", trimToEmpty(targetHosts), "resources", fileStringList));
-	}
-
-
-	/**
-	 * Get the status of the given perf test.
-	 *
-	 * @param user user
-	 * @param id   perftest id
-	 * @return JSON message containing perf test status
-	 */
-	@RestAPI
-	@RequestMapping("/api/{id}/status")
-	public HttpEntity<String> getStatus(User user, @PathVariable("id") Long id) {
-		List<PerfTest> perfTests = perfTestService.getAll(user, new Long[]{id});
-		return toJsonHttpEntity(buildMap("status", getStatus(perfTests)));
-	}
-
-	/**
-	 * Get the logs of the given perf test.
-	 *
-	 * @param user user
-	 * @param id   perftest id
-	 * @return JSON message containing log file names
-	 */
-	@RestAPI
-	@RequestMapping("/api/{id}/logs")
-	public HttpEntity<String> getLogs(User user, @PathVariable("id") Long id) {
-		// Check permission
-		getOneWithPermissionCheck(user, id, false);
-		return toJsonHttpEntity(perfTestService.getLogFiles(id));
-	}
-
-	/**
-	 * Get the detailed report graph data for the given perf test id.
-	 * This method returns the appropriate points based on the given imgWidth.
-	 *
-	 * @param id       test id
-	 * @param dataType which data
-	 * @param imgWidth imageWidth
-	 * @return json string.
-	 */
-	@SuppressWarnings("MVCPathVariableInspection")
-	@RestAPI
-	@RequestMapping({"/api/{id}/perf", "/api/{id}/graph"})
-	public HttpEntity<String> getPerfGraph(@PathVariable("id") long id,
-	                                       @RequestParam(required = true, defaultValue = "") String dataType,
-	                                       @RequestParam(defaultValue = "false") boolean onlyTotal,
-	                                       @RequestParam int imgWidth) {
-		String[] dataTypes = checkNotEmpty(StringUtils.split(dataType, ","), "dataType argument should be provided");
-		return toJsonHttpEntity(getPerfGraphData(id, dataTypes, onlyTotal, imgWidth));
-	}
-
-
-	/**
-	 * Get the monitor data of the target having the given IP.
-	 *
-	 * @param id       test Id
-	 * @param targetIP targetIP
-	 * @param imgWidth image width
-	 * @return json message
-	 */
-	@RestAPI
-	@RequestMapping("/api/{id}/monitor")
-	public HttpEntity<String> getMonitorGraph(@PathVariable("id") long id,
-	                                          @RequestParam("targetIP") String targetIP, @RequestParam int imgWidth) {
-		return toJsonHttpEntity(getMonitorGraphData(id, targetIP, imgWidth));
-	}
-
-	/**
-	 * Get the plugin monitor data of the target.
-	 *
-	 * @param id       test Id
-	 * @param plugin   monitor plugin category
-	 * @param kind     kind
-	 * @param imgWidth image width
-	 * @return json message
-	 */
-	@RestAPI
-	@RequestMapping("/api/{id}/plugin/{plugin}")
-	public HttpEntity<String> getPluginGraph(@PathVariable("id") long id,
-	                                         @PathVariable("plugin") String plugin,
-	                                         @RequestParam("kind") String kind, @RequestParam int imgWidth) {
-		return toJsonHttpEntity(getReportPluginGraphData(id, plugin, kind, imgWidth));
-	}
-
-	private Map<String, Object> getReportPluginGraphData(long id, String plugin, String kind, int imgWidth) {
-		int interval = perfTestService.getReportPluginGraphInterval(id, plugin, kind, imgWidth);
-		Map<String, Object> pluginMonitorData = perfTestService.getReportPluginGraph(id, plugin, kind, interval);
-		final PerfTest perfTest = perfTestService.getOne(id);
-		int samplingInterval = 3;
-		if (perfTest != null) {
-			samplingInterval = perfTest.getSamplingInterval();
-		}
-		pluginMonitorData.put("interval", interval * samplingInterval);
-		return pluginMonitorData;
-	}
-
-
-	/**
-	 * Get the last perf test details in the form of json.
-	 *
-	 * @param user user
-	 * @param page page
-	 * @param size size of retrieved perf test
-	 * @return json string
-	 */
-	@RestAPI
-	@RequestMapping(value = {"/api/last", "/api", "/api/"}, method = RequestMethod.GET)
-	public HttpEntity<String> getAll(User user, @RequestParam(value = "page", defaultValue = "0") int page,
-	                                 @RequestParam(value = "size", defaultValue = "1") int size) {
-		PageRequest pageRequest = PageRequest.of(page, size, new Sort(Direction.DESC, "id"));
-		Page<PerfTest> testList = perfTestService.getPagedAll(user, null, null, null, pageRequest);
-		return toJsonHttpEntity(testList.getContent());
-	}
-
-	/**
-	 * Get the perf test detail in the form of json.
-	 *
-	 * @param user user
-	 * @param id   perftest id
-	 * @return json message containing test info.
-	 */
-	@RestAPI
-	@RequestMapping(value = "/api/{id}", method = RequestMethod.GET)
-	public HttpEntity<String> getOne(User user, @PathVariable("id") Long id) {
-		PerfTest test = checkNotNull(getOneWithPermissionCheck(user, id, false), "PerfTest %s does not exists", id);
-		return toJsonHttpEntity(test);
-	}
-
-	/**
-	 * Create the given perf test.
-	 *
-	 * @param user     user
-	 * @param perfTest perf test
-	 * @return json message containing test info.
-	 */
-	@RestAPI
-	@RequestMapping(value = {"/api/", "/api"}, method = RequestMethod.POST)
-	public HttpEntity<String> create(User user, PerfTest perfTest) {
-		checkNull(perfTest.getId(), "id should be null");
-		// Make the vuser count optional.
-		if (perfTest.getVuserPerAgent() == null && perfTest.getThreads() != null && perfTest.getProcesses() != null) {
-			perfTest.setVuserPerAgent(perfTest.getThreads() * perfTest.getProcesses());
-		}
-		validate(user, null, perfTest);
-		PerfTest savePerfTest = perfTestService.save(user, perfTest);
-		return toJsonHttpEntity(savePerfTest);
-	}
-
-	/**
-	 * Delete the given perf test.
-	 *
-	 * @param user user
-	 * @param id   perf test id
-	 * @return json success message if succeeded
-	 */
-	@RestAPI
-	@RequestMapping(value = "/api/{id}", method = RequestMethod.DELETE)
-	public HttpEntity<String> delete(User user, @PathVariable("id") Long id) {
-		PerfTest perfTest = getOneWithPermissionCheck(user, id, false);
-		checkNotNull(perfTest, "no perftest for %s exits", id);
-		perfTestService.delete(user, id);
-		return successJsonHttpEntity();
-	}
-
-
-	/**
-	 * Update the given perf test.
-	 *
-	 * @param user     user
-	 * @param id       perf test id
-	 * @param perfTest perf test configuration changes
-	 * @return json message
-	 */
-	@RestAPI
-	@RequestMapping(value = "/api/{id}", method = RequestMethod.PUT)
-	public HttpEntity<String> update(User user, @PathVariable("id") Long id, PerfTest perfTest) {
-		PerfTest existingPerfTest = getOneWithPermissionCheck(user, id, false);
-		perfTest.setId(id);
-		validate(user, existingPerfTest, perfTest);
-		return toJsonHttpEntity(perfTestService.save(user, perfTest));
-	}
-
-	/**
-	 * Stop the given perf test.
-	 *
-	 * @param user user
-	 * @param id   perf test id
-	 * @return json success message if succeeded
-	 */
-	@RestAPI
-	@RequestMapping(value = "/api/{id}", params = "action=stop", method = RequestMethod.PUT)
-	public HttpEntity<String> stop(User user, @PathVariable("id") Long id) {
-		perfTestService.stop(user, id);
-		return successJsonHttpEntity();
-	}
-
-
-	/**
-	 * Update the given perf test's status.
-	 *
-	 * @param user   user
-	 * @param id     perf test id
-	 * @param status Status to be moved to
-	 * @return json message
-	 */
-	@RestAPI
-	@RequestMapping(value = "/api/{id}", params = "action=status", method = RequestMethod.PUT)
-	public HttpEntity<String> updateStatus(User user, @PathVariable("id") Long id, Status status) {
-		PerfTest perfTest = getOneWithPermissionCheck(user, id, false);
-		checkNotNull(perfTest, "no perftest for %s exits", id).setStatus(status);
-		validate(user, null, perfTest);
-		return toJsonHttpEntity(perfTestService.save(user, perfTest));
-	}
-
-	/**
-	 * Clone and start the given perf test.
-	 *
-	 * @param user     user
-	 * @param id       perf test id to be cloned
-	 * @param perftest option to override while cloning.
-	 * @return json string
-	 */
-	@SuppressWarnings("MVCPathVariableInspection")
-	@RestAPI
-	@RequestMapping(value = {"/api/{id}/clone_and_start", /* for backward compatibility */ "/api/{id}/cloneAndStart"})
-	public HttpEntity<String> cloneAndStart(User user, @PathVariable("id") Long id, PerfTest perftest) {
-		PerfTest test = getOneWithPermissionCheck(user, id, false);
-		checkNotNull(test, "no perftest for %s exits", id);
-		PerfTest newOne = test.cloneTo(new PerfTest());
-		newOne.setStatus(Status.READY);
-		if (perftest != null) {
-			if (perftest.getScheduledTime() != null) {
-				newOne.setScheduledTime(perftest.getScheduledTime());
-			}
-			if (perftest.getScriptRevision() != null) {
-				newOne.setScriptRevision(perftest.getScriptRevision());
-			}
-
-			if (perftest.getAgentCount() != null) {
-				newOne.setAgentCount(perftest.getAgentCount());
-			}
-		}
-		if (newOne.getAgentCount() == null) {
-			newOne.setAgentCount(0);
-		}
-		Map<String, MutableInt> agentCountMap = agentManagerService.getAvailableAgentCountMap(user);
-		MutableInt agentCountObj = agentCountMap.get(isClustered() ? test.getRegion() : Config.NONE_REGION);
-		checkNotNull(agentCountObj, "test region should be within current region list");
-		int agentMaxCount = agentCountObj.intValue();
-		checkArgument(newOne.getAgentCount() != 0, "test agent should not be %s", agentMaxCount);
-		checkArgument(newOne.getAgentCount() <= agentMaxCount, "test agent should be equal to or less than %s",
-				agentMaxCount);
-		PerfTest savePerfTest = perfTestService.save(user, newOne);
-		CoreLogger.LOGGER.info("test {} is created through web api by {}", savePerfTest.getId(), user.getUserId());
-		return toJsonHttpEntity(savePerfTest);
-	}
-
 }

--- a/ngrinder-controller/src/main/java/org/ngrinder/script/controller/FileEntryApiController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/script/controller/FileEntryApiController.java
@@ -1,0 +1,161 @@
+/* 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. 
+ */
+package org.ngrinder.script.controller;
+
+import org.ngrinder.common.controller.RestAPI;
+import org.ngrinder.infra.spring.RemainedPath;
+import org.ngrinder.model.User;
+import org.ngrinder.script.model.FileEntry;
+import org.ngrinder.script.service.ScriptValidationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.ngrinder.common.util.Preconditions.checkNotNull;
+
+/**
+ * FileEntry manipulation api controller.
+ *
+ * @since 3.5.0
+ */
+@RestController
+@RequestMapping("/script")
+public class FileEntryApiController extends FileEntryBaseController {
+
+	@Autowired
+	private ScriptValidationService scriptValidationService;
+
+	/**
+	 * Delete files on the given path.
+	 *
+	 * @param user        user
+	 * @param path        base path
+	 * @param filesString file list delimited by ","
+	 * @return json string
+	 */
+	@RequestMapping(value = "/delete/**", method = RequestMethod.POST)
+	public String delete(User user, @RemainedPath String path, @RequestParam("filesString") String filesString) {
+		String[] files = filesString.split(",");
+		fileEntryService.delete(user, path, files);
+		return returnSuccess();
+	}
+
+	/**
+	 * Create the given file.
+	 *
+	 * @param user      user
+	 * @param fileEntry file entry
+	 * @return success json string
+	 */
+	@RestAPI
+	@RequestMapping(value = {"/api/", "/api"}, method = RequestMethod.POST)
+	public String create(User user, FileEntry fileEntry) {
+		fileEntryService.save(user, fileEntry);
+		return returnSuccess();
+	}
+
+	/**
+	 * Create the given file.
+	 *
+	 * @param user        user
+	 * @param path        path
+	 * @param description description
+	 * @param file        multi part file
+	 * @return success json string
+	 */
+	@RestAPI
+	@RequestMapping(value = "/api/**", params = "action=upload", method = RequestMethod.POST)
+	public String uploadForAPI(User user, @RemainedPath String path,
+							   @RequestParam("description") String description,
+							   @RequestParam("uploadFile") MultipartFile file) throws IOException {
+		upload(user, path, description, file);
+		return returnSuccess();
+	}
+
+	/**
+	 * Check the file by given path.
+	 *
+	 * @param user user
+	 * @param path path
+	 * @return json string
+	 */
+	@RestAPI
+	@RequestMapping(value = "/api/**", params = "action=view")
+	public FileEntry viewOne(User user, @RemainedPath String path) {
+		FileEntry fileEntry = fileEntryService.getOne(user, path, -1L);
+		return checkNotNull(fileEntry, "%s file is not viewable", path);
+	}
+
+	/**
+	 * Get all files which belongs to given user.
+	 *
+	 * @param user user
+	 * @return json string
+	 */
+	@RestAPI
+	@RequestMapping(value = {"/api/**", "/api/", "/api"}, params = "action=all")
+	public List<FileEntry> getAll(User user) {
+		return fileEntryService.getAll(user);
+	}
+
+	/**
+	 * Get all files which belongs to given user and path.
+	 *
+	 * @param user user
+	 * @param path path
+	 * @return json string
+	 */
+	@RestAPI
+	@RequestMapping({"/api/**", "/api/", "/api"})
+	public List<FileEntry> getAll(User user, @RemainedPath String path) {
+		return getAllFiles(user, path);
+	}
+
+	/**
+	 * Delete file by given user and path.
+	 *
+	 * @param user user
+	 * @param path path
+	 * @return json string
+	 */
+	@RestAPI
+	@RequestMapping(value = "/api/**", method = RequestMethod.DELETE)
+	public String deleteOne(User user, @RemainedPath String path) {
+		fileEntryService.delete(user, path);
+		return returnSuccess();
+	}
+
+
+	/**
+	 * Validate the script.
+	 *
+	 * @param user       current user
+	 * @param fileEntry  fileEntry
+	 * @param hostString hostString
+	 * @return validation Result string
+	 */
+	@RestAPI
+	@RequestMapping(value = "/api/validate", method = RequestMethod.POST)
+	public String validate(User user, FileEntry fileEntry,
+						   @RequestParam(value = "hostString", required = false) String hostString) {
+		fileEntry.setCreatedUser(user);
+		return scriptValidationService.validate(user, fileEntry, false, hostString);
+	}
+}

--- a/ngrinder-controller/src/main/java/org/ngrinder/script/controller/FileEntryBaseController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/script/controller/FileEntryBaseController.java
@@ -1,0 +1,130 @@
+/* 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. 
+ */
+package org.ngrinder.script.controller;
+
+import com.google.common.base.Predicate;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.StringUtils;
+import org.ngrinder.common.controller.BaseController;
+import org.ngrinder.common.util.HttpContainerContext;
+import org.ngrinder.model.User;
+import org.ngrinder.script.model.FileEntry;
+import org.ngrinder.script.model.FileType;
+import org.ngrinder.script.service.FileEntryService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+
+import static com.google.common.collect.Iterables.filter;
+import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Collections.sort;
+import static org.apache.commons.io.FilenameUtils.getPath;
+import static org.ngrinder.common.util.PathUtils.removePrependedSlash;
+import static org.ngrinder.common.util.PathUtils.trimPathSeparatorBothSides;
+
+/**
+ * FileEntry manipulation base controller.
+ *
+ * @since 3.5.0
+ */
+public class FileEntryBaseController extends BaseController {
+
+	@Autowired
+	protected FileEntryService fileEntryService;
+
+	@Autowired
+	protected HttpContainerContext httpContainerContext;
+
+	/**
+	 * Get the SVN url BreadCrumbs HTML string.
+	 *
+	 * @param user user
+	 * @param path path
+	 * @return generated HTML
+	 */
+	public String getSvnUrlBreadcrumbs(User user, String path) {
+		String contextPath = httpContainerContext.getCurrentContextUrlFromUserRequest();
+		String[] parts = StringUtils.split(path, '/');
+		StringBuilder accumulatedPart = new StringBuilder(contextPath).append("/script/list");
+		StringBuilder returnHtml = new StringBuilder().append("<a href='").append(accumulatedPart).append("'>")
+				.append(contextPath).append("/svn/").append(user.getUserId()).append("</a>");
+		for (String each : parts) {
+			returnHtml.append("/");
+			accumulatedPart.append("/").append(each);
+			returnHtml.append("<a href='").append(accumulatedPart).append("'>").append(each).append("</a>");
+		}
+		return returnHtml.toString();
+	}
+
+	/**
+	 * Get the script path BreadCrumbs HTML string.
+	 *
+	 * @param path path
+	 * @return generated HTML
+	 */
+	public String getScriptPathBreadcrumbs(String path) {
+		String contextPath = httpContainerContext.getCurrentContextUrlFromUserRequest();
+		String[] parts = StringUtils.split(path, '/');
+		StringBuilder accumulatedPart = new StringBuilder(contextPath).append("/script/list");
+		StringBuilder returnHtml = new StringBuilder();
+		for (int i = 0; i < parts.length; i++) {
+			String each = parts[i];
+			accumulatedPart.append("/").append(each);
+			if (i != parts.length - 1) {
+				returnHtml.append("<a target='_path_view' href='").append(accumulatedPart).append("'>").append(each)
+						.append("</a>").append("/");
+			} else {
+				returnHtml.append(each);
+			}
+		}
+		return returnHtml.toString();
+	}
+
+	protected List<FileEntry> getAllFiles(User user, String path) {
+		final String trimmedPath = StringUtils.trimToEmpty(path);
+		List<FileEntry> files = newArrayList(filter(fileEntryService.getAll(user),
+				new Predicate<FileEntry>() {
+					@Override
+					public boolean apply(@Nullable FileEntry input) {
+						return input != null && trimPathSeparatorBothSides(getPath(input.getPath())).equals(trimmedPath);
+					}
+				}));
+		sort(files, new Comparator<FileEntry>() {
+			@Override
+			public int compare(FileEntry o1, FileEntry o2) {
+				if (o1.getFileType() == FileType.DIR && o2.getFileType() != FileType.DIR) {
+					return -1;
+				}
+				return (o1.getFileName().compareTo(o2.getFileName()));
+			}
+
+		});
+		for (FileEntry each : files) {
+			each.setPath(removePrependedSlash(each.getPath()));
+		}
+		return files;
+	}
+
+	protected void upload(User user, String path, String description, MultipartFile file) throws IOException {
+		FileEntry fileEntry = new FileEntry();
+		fileEntry.setContentBytes(file.getBytes());
+		fileEntry.setDescription(description);
+		fileEntry.setPath(FilenameUtils.separatorsToUnix(FilenameUtils.concat(path, file.getOriginalFilename())));
+		fileEntryService.save(user, fileEntry);
+	}
+}

--- a/ngrinder-controller/src/main/resources/application.yml
+++ b/ngrinder-controller/src/main/resources/application.yml
@@ -24,4 +24,6 @@ spring:
       - org.springframework.boot.autoconfigure.freemarker.FreeMarkerAutoConfiguration
   profiles:
     active: production
+  jackson:
+    default-property-inclusion: non_null
 

--- a/ngrinder-controller/src/test/java/org/ngrinder/operation/LogMonitorControllerTest.java
+++ b/ngrinder-controller/src/test/java/org/ngrinder/operation/LogMonitorControllerTest.java
@@ -13,8 +13,6 @@
  */
 package org.ngrinder.operation;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParser;
 import org.junit.Test;
 import org.ngrinder.AbstractNGrinderTransactionalTest;
 import org.ngrinder.infra.config.Config;
@@ -23,7 +21,8 @@ import org.ngrinder.operation.cotroller.LogMonitorController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpEntity;
+
+import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
@@ -66,10 +65,7 @@ public class LogMonitorControllerTest extends AbstractNGrinderTransactionalTest 
 	}
 
 	private String getLastMessage() {
-		HttpEntity<String> lastLog = logMonitorController.getLast();
-		JsonParser parser = new JsonParser();
-		JsonElement parse = parser.parse(lastLog.getBody());
-		String message = parse.getAsJsonObject().get("log").getAsString();
-		return message;
+		Map<String, Object> lastLog = logMonitorController.getLast();
+		return lastLog.get("log").toString();
 	}
 }

--- a/ngrinder-controller/src/test/java/org/ngrinder/perftest/controller/MockPerfTestApiController.java
+++ b/ngrinder-controller/src/test/java/org/ngrinder/perftest/controller/MockPerfTestApiController.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.when;
 
 @Profile("unit-test")
 @Component
-public class MockPerfTestController extends PerfTestController {
+public class MockPerfTestApiController extends PerfTestApiController {
 
 	@Autowired
 	private UserContext userContext;

--- a/ngrinder-controller/src/test/java/org/ngrinder/perftest/controller/PerfTestControllerTest.java
+++ b/ngrinder-controller/src/test/java/org/ngrinder/perftest/controller/PerfTestControllerTest.java
@@ -33,7 +33,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.http.HttpEntity;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.ui.ModelMap;
 
@@ -42,6 +41,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
@@ -55,7 +55,10 @@ import static org.junit.Assert.*;
 public class PerfTestControllerTest extends AbstractPerfTestTransactionalTest implements WebConstants {
 
 	@Autowired
-	private MockPerfTestController controller;
+	private MockPerfTestApiController mockPerfTestApiController;
+
+	@Autowired
+	private MockPerfTestController mockPerfTestController;
 
 	@Autowired
 	private Config config;
@@ -74,20 +77,20 @@ public class PerfTestControllerTest extends AbstractPerfTestTransactionalTest im
 	@Test
 	public void testGetPerfTestDetail() {
 		ModelMap model = new ModelMap();
-		controller.getOne(getTestUser(), null, model);
+		mockPerfTestController.getOne(getTestUser(), null, model);
 		assertThat(model.get(PARAM_TEST), notNullValue());
 		model.clear();
 
-		controller.getOne(getTestUser(), 0L, model);
+		mockPerfTestController.getOne(getTestUser(), 0L, model);
 		assertThat(model.get(PARAM_TEST), notNullValue());
 		model.clear();
 		long invalidId = 123123123123L;
-		controller.getOne(getTestUser(), invalidId, model);
+		mockPerfTestController.getOne(getTestUser(), invalidId, model);
 		assertThat(model.get(PARAM_TEST), notNullValue());
 
 		PerfTest createPerfTest = createPerfTest("hello", Status.READY, new Date());
 		model.clear();
-		controller.getOne(getTestUser(), createPerfTest.getId(), model);
+		mockPerfTestController.getOne(getTestUser(), createPerfTest.getId(), model);
 		assertThat(model.get(PARAM_TEST), notNullValue());
 
 	}
@@ -98,7 +101,7 @@ public class PerfTestControllerTest extends AbstractPerfTestTransactionalTest im
 		FileUtils.deleteQuietly(file);
 		CompressionUtils.unzip(new ClassPathResource("TEST_USER.zip").getFile(), file);
 		repo.setUserRepository(new File(file, getTestUser().getUserId()));
-		controller.getResources(getTestUser(), "filefilter.txt", null);
+		mockPerfTestApiController.getResources(getTestUser(), "filefilter.txt", null);
 	}
 
 	@Test
@@ -106,18 +109,18 @@ public class PerfTestControllerTest extends AbstractPerfTestTransactionalTest im
 		String testName = "test1";
 		PerfTest test = createPerfTest(testName, Status.READY, new Date());
 		ModelMap model = new ModelMap();
-		controller.delete(getTestUser(), String.valueOf(test.getId()));
+		mockPerfTestApiController.delete(getTestUser(), String.valueOf(test.getId()));
 		model.clear();
 		PerfTest test1 = createPerfTest(testName, Status.READY, new Date());
 		PerfTest test2 = createPerfTest(testName, Status.READY, new Date());
 		String delIds = "" + test1.getId() + "," + test2.getId();
-		controller.delete(getTestUser(), delIds);
+		mockPerfTestApiController.delete(getTestUser(), delIds);
 
 		model.clear();
-		controller.getOne(getTestUser(), test1.getId(), model);
+		mockPerfTestController.getOne(getTestUser(), test1.getId(), model);
 		assertThat(((PerfTest) model.get(PARAM_TEST)).getId(), nullValue());
 		model.clear();
-		controller.getOne(getTestUser(), test2.getId(), model);
+		mockPerfTestController.getOne(getTestUser(), test2.getId(), model);
 		assertThat(((PerfTest) model.get(PARAM_TEST)).getId(), nullValue());
 	}
 
@@ -131,20 +134,20 @@ public class PerfTestControllerTest extends AbstractPerfTestTransactionalTest im
 		cloneTest.setId(test.getId()); // set cloned test's ID as previous test
 
 		ModelMap model = new ModelMap();
-		controller.saveOne(getTestUser(), cloneTest, true, model);
+		mockPerfTestController.saveOne(getTestUser(), cloneTest, true, model);
 		assertThat(preId, not(cloneTest.getId()));
 
 		// test leave comment
-		controller.leaveComment(getTestUser(), cloneTest.getId(), "TestComment", "");
+		mockPerfTestApiController.leaveComment(getTestUser(), cloneTest.getId(), "TestComment", "");
 		model.clear();
-		controller.getOne(getTestUser(), cloneTest.getId(), model);
+		mockPerfTestController.getOne(getTestUser(), cloneTest.getId(), model);
 		PerfTest testInDB = (PerfTest) model.get(PARAM_TEST);
 		assertThat(testInDB.getTestComment(), is("TestComment"));
 
 		// test stop test
 		cloneTest.setStatus(Status.TESTING);
 		perfTestService.save(getTestUser(), cloneTest);
-		controller.stop(getTestUser(), String.valueOf(cloneTest.getId()));
+		mockPerfTestApiController.stop(getTestUser(), String.valueOf(cloneTest.getId()));
 	}
 
 	/**
@@ -174,18 +177,19 @@ public class PerfTestControllerTest extends AbstractPerfTestTransactionalTest im
 		newTest.setVuserPerAgent(newTest.getProcesses() * newTest.getThreads());
 		newTest.setRegion(config.getRegion());
 		newTest.setAgentCount(1);
+		newTest.setCreatedUser(getTestUser());
 
 		ModelMap model = new ModelMap();
-		controller.saveOne(getTestUser(), newTest, false, model);
-		controller.getOne(getTestUser(), newTest.getId(), model);
+		mockPerfTestController.saveOne(getTestUser(), newTest, false, model);
+		mockPerfTestController.getOne(getTestUser(), newTest.getId(), model);
 		PerfTest testInDB = (PerfTest) model.get(PARAM_TEST);
 		assertThat(testInDB.getTestName(), is(newName));
 		assertThat(testInDB.getId(), is(test.getId()));
 
 		model.clear();
 		newTest.setStatus(Status.READY);
-		controller.saveOne(getTestUser(), newTest, false, model);
-		controller.getOne(getTestUser(), newTest.getId(), model);
+		mockPerfTestController.saveOne(getTestUser(), newTest, false, model);
+		mockPerfTestController.getOne(getTestUser(), newTest.getId(), model);
 		testInDB = (PerfTest) model.get(PARAM_TEST);
 		assertThat(testInDB.getTestName(), is(newName));
 		assertThat(testInDB.getId(), is(test.getId()));
@@ -194,7 +198,7 @@ public class PerfTestControllerTest extends AbstractPerfTestTransactionalTest im
 		newTest.setStatus(Status.START_TESTING);
 		try {
 			newTest.setStatus(Status.START_TESTING);
-			controller.saveOne(getTestUser(), newTest, false, model);
+			mockPerfTestController.saveOne(getTestUser(), newTest, false, model);
 			fail("test status id START_TESTING, can not be saved");
 		} catch (IllegalArgumentException e) {
 		}
@@ -205,7 +209,7 @@ public class PerfTestControllerTest extends AbstractPerfTestTransactionalTest im
 	public void testGetTestList() {
 		createPerfTest("new test1", Status.READY, new Date());
 		ModelMap model = new ModelMap();
-		controller.getAll(getTestUser(), null, null, null, new PageRequest(0, 10), model);
+		mockPerfTestController.getAll(getTestUser(), null, null, null, new PageRequest(0, 10), model);
 		Page<PerfTest> testPage = (Page<PerfTest>) model.get("testListPage");
 		List<PerfTest> testList = testPage.getContent();
 		assertThat(testList.size(), is(1));
@@ -223,7 +227,7 @@ public class PerfTestControllerTest extends AbstractPerfTestTransactionalTest im
 		testAdmin.setTimeZone("Asia/Seoul");
 		testAdmin = userService.save(testAdmin);
 
-		controller.getAll(testAdmin, null, null, null, new PageRequest(0, 10), model);
+		mockPerfTestController.getAll(testAdmin, null, null, null, new PageRequest(0, 10), model);
 		@SuppressWarnings("unchecked")
 		Page<PerfTest> testPage = (Page<PerfTest>) model.get("testListPage");
 		List<PerfTest> testList = testPage.getContent();
@@ -249,7 +253,7 @@ public class PerfTestControllerTest extends AbstractPerfTestTransactionalTest im
 		otherTestUser.setRole(Role.USER);
 		otherTestUser = userService.save(otherTestUser);
 		otherTestUser.setTimeZone("Asia/Seoul");
-		controller.getAll(otherTestUser, null, null, null, new PageRequest(0, 10), model);
+		mockPerfTestController.getAll(otherTestUser, null, null, null, new PageRequest(0, 10), model);
 		@SuppressWarnings("unchecked")
 		Page<PerfTest> testPage = (Page<PerfTest>) model.get("testListPage");
 		List<PerfTest> testList = testPage.getContent();
@@ -259,7 +263,7 @@ public class PerfTestControllerTest extends AbstractPerfTestTransactionalTest im
 		// test no permission for other user
 		model.clear();
 		try {
-			controller.getOne(otherTestUser, test.getId(), model);
+			mockPerfTestController.getOne(otherTestUser, test.getId(), model);
 			assertTrue(false);
 		} catch (NGrinderRuntimeException e) {
 			assertTrue(true);
@@ -276,12 +280,12 @@ public class PerfTestControllerTest extends AbstractPerfTestTransactionalTest im
 
 		Sort sort = new Sort("testName");
 		Pageable pageable = new PageRequest(0, 10, sort);
-		controller.getAll(getTestUser(), strangeName, null, null, pageable, model);
+		mockPerfTestController.getAll(getTestUser(), strangeName, null, null, pageable, model);
 		Page<PerfTest> testPage = (Page<PerfTest>) model.get("testListPage");
 		List<PerfTest> testList = testPage.getContent();
 		assertThat(testList.size(), is(1));
 
-		controller.getAll(getTestUser(), strangeName.substring(2, 10), null, null, new PageRequest(0, 10), model);
+		mockPerfTestController.getAll(getTestUser(), strangeName.substring(2, 10), null, null, new PageRequest(0, 10), model);
 		testPage = (Page<PerfTest>) model.get("testListPage");
 		testList = testPage.getContent();
 		assertThat(testList.size(), is(1));
@@ -292,23 +296,23 @@ public class PerfTestControllerTest extends AbstractPerfTestTransactionalTest im
 		String testName = "test1";
 		PerfTest test = createPerfTest(testName, Status.FINISHED, new Date());
 		ModelMap model = new ModelMap();
-		controller.getReport(model, test.getId());
+		mockPerfTestController.getReport(model, test.getId());
 
 		model.clear();
-		controller.getPerfGraph(test.getId(), "TPS,mean_time(ms)", true, 0);
+		mockPerfTestApiController.getPerfGraph(test.getId(), "TPS,mean_time(ms)", true, 0);
 
 		model.clear();
-		controller.getReportSection(getTestUser(), model, test.getId(), 700);
+		mockPerfTestController.getReportSection(getTestUser(), model, test.getId(), 700);
 	}
 
 	@Test
 	public void testGetMonitorData() {
 		String testName = "test1";
 		PerfTest test = createPerfTest(testName, Status.FINISHED, new Date());
-		controller.getMonitorGraph(test.getId(), "127.0.0.1", 0);
+		mockPerfTestApiController.getMonitorGraph(test.getId(), "127.0.0.1", 0);
 
 		long testId = 123456L;
-		controller.getMonitorGraph(testId, "127.0.0.1", 700);
+		mockPerfTestApiController.getMonitorGraph(testId, "127.0.0.1", 700);
 	}
 
 	@Test
@@ -317,23 +321,23 @@ public class PerfTestControllerTest extends AbstractPerfTestTransactionalTest im
 		PerfTest test = createPerfTest(testName, Status.FINISHED, new Date());
 		HttpServletResponse resp = new MockHttpServletResponse();
 		try {
-			controller.downloadCSV(getTestUser(), test.getId(), resp);
+			mockPerfTestController.downloadCSV(getTestUser(), test.getId(), resp);
 		} catch (IllegalStateException e) {
 			// the report file doesn't exist
 			assertTrue(true);
 		}
 		resp.reset();
-		controller.downloadLog(getTestUser(), test.getId(), "log", resp);
+		mockPerfTestController.downloadLog(getTestUser(), test.getId(), "log", resp);
 	}
 
 	@Test
-	public void testRefreshTestRunning() {
+	public void testRefreshTestRunning() throws IOException {
 		String testName = "test1";
 		// it is not a running test, can not test get statistic data.
 		PerfTest test = createPerfTest(testName, Status.TESTING, new Date());
 		test.setPort(11011);
 		try {
-			controller.refreshTestRunning(getTestUser(), test.getId());
+			mockPerfTestApiController.refreshTestRunning(getTestUser(), test.getId());
 		} catch (NullPointerException e) {
 			assertTrue(true);
 		}
@@ -347,16 +351,16 @@ public class PerfTestControllerTest extends AbstractPerfTestTransactionalTest im
 		PerfTest test2 = createPerfTest(testName2, Status.START_AGENTS, new Date());
 
 		String ids = test.getId() + "," + test2.getId();
-		HttpEntity<String> rtnJson = controller.getStatuses(getTestUser(), ids);
-		assertThat(rtnJson.getBody(), notNullValue());
+		Map<String, Object> rtnJson = mockPerfTestApiController.getStatuses(getTestUser(), ids);
+		assertThat(rtnJson, notNullValue());
 	}
 
 	@Test
 	public void testSearchTag() {
-		HttpEntity<String> rtn = controller.searchTag(getAdminUser(), "");
-		assertThat(rtn.getBody(), notNullValue());
-		rtn = controller.searchTag(getAdminUser(), "test");
-		assertThat(rtn.getBody(), notNullValue());
+		List<String> rtn = mockPerfTestApiController.searchTag(getAdminUser(), "");
+		assertThat(rtn, notNullValue());
+		rtn = mockPerfTestApiController.searchTag(getAdminUser(), "test");
+		assertThat(rtn, notNullValue());
 	}
 
 }

--- a/ngrinder-controller/src/test/java/org/ngrinder/perftest/service/PerfTestCancellationTest.java
+++ b/ngrinder-controller/src/test/java/org/ngrinder/perftest/service/PerfTestCancellationTest.java
@@ -22,6 +22,7 @@ import org.ngrinder.common.constant.ControllerConstants;
 import org.ngrinder.common.util.CompressionUtils;
 import org.ngrinder.model.PerfTest;
 import org.ngrinder.model.Status;
+import org.ngrinder.perftest.controller.PerfTestApiController;
 import org.ngrinder.perftest.controller.PerfTestController;
 import org.ngrinder.script.model.FileEntry;
 import org.ngrinder.script.repository.MockFileEntityRepository;
@@ -50,6 +51,9 @@ public class PerfTestCancellationTest extends AbstractAgentReadyTest implements 
 
 	@Autowired
 	public PerfTestController perfTestController;
+
+	@Autowired
+	public PerfTestApiController perfTestApiController;
 
 	private PerfTest perfTest = null;
 
@@ -100,7 +104,7 @@ public class PerfTestCancellationTest extends AbstractAgentReadyTest implements 
 				SampleModelImplementationEx sampleModelMock = mock(SampleModelImplementationEx.class);
 				singleConsole.setSampleModel(sampleModelMock);
 				assertThat(singleConsole, notNullValue());
-				perfTestController.stop(getTestUser(), String.valueOf(perfTest.getId()));
+				perfTestApiController.stop(getTestUser(), String.valueOf(perfTest.getId()));
 			}
 		}, substep);
 		perfTestRunnable.doStart();
@@ -116,7 +120,7 @@ public class PerfTestCancellationTest extends AbstractAgentReadyTest implements 
 		// Given the testing perftest
 		perfTest = createPerfTest("test1", Status.TESTING, null);
 		// When the stop is requested
-		perfTestController.stop(getTestUser(), String.valueOf(perfTest.getId()));
+		perfTestApiController.stop(getTestUser(), String.valueOf(perfTest.getId()));
 		perfTestRunnable.doFinish();
 		// Then it should be canceled.
 		assertThat(perfTestService.getOne(perfTest.getId()).getStatus(), is(Status.CANCELED));

--- a/ngrinder-controller/src/test/java/org/ngrinder/perftest/service/PerfTestRunnableTest.java
+++ b/ngrinder-controller/src/test/java/org/ngrinder/perftest/service/PerfTestRunnableTest.java
@@ -99,7 +99,7 @@ public class PerfTestRunnableTest extends AbstractAgentReadyTest implements Cont
 	}
 
 	@Test
-	public void testDoTest() throws IOException {
+	public void testDoTest() {
 		assertThat(agentManager.getAllApprovedAgents().size(), is(1));
 		perfTestRunnable.doStart();
 		sleep(10000);
@@ -115,7 +115,7 @@ public class PerfTestRunnableTest extends AbstractAgentReadyTest implements Cont
 	boolean ended = false;
 
 	@Test
-	public void testStartConsole() throws IOException {
+	public void testStartConsole() {
 		// Get perf test
 		PerfTest perfTest = perfTestService.getNextRunnablePerfTestPerfTestCandidate();
 		perfTest.setScriptName("/hello/world.py");

--- a/ngrinder-controller/src/test/java/org/ngrinder/script/controller/FileEntryControllerTest.java
+++ b/ngrinder-controller/src/test/java/org/ngrinder/script/controller/FileEntryControllerTest.java
@@ -49,6 +49,9 @@ public class FileEntryControllerTest extends AbstractNGrinderTransactionalTest {
 	private FileEntryController scriptController;
 
 	@Autowired
+	private FileEntryApiController scriptApiController;
+
+	@Autowired
 	private MockFileEntityRepository fileEntityRepository;
 
 	@Autowired
@@ -81,7 +84,7 @@ public class FileEntryControllerTest extends AbstractNGrinderTransactionalTest {
 		FileEntry script = (FileEntry) model.get("file");
 		script.setContent(script.getContent() + "#test comment");
 		scriptController.save(getTestUser(), script, null, "", false, model);
-		scriptController.validate(getTestUser(), script, "test.com");
+		scriptApiController.validate(getTestUser(), script, "test.com");
 		// save and get
 		model.clear();
 		scriptController.getOne(getTestUser(), script.getPath(), -1L, model);
@@ -96,7 +99,7 @@ public class FileEntryControllerTest extends AbstractNGrinderTransactionalTest {
 		scriptController.search(getTestUser(), "test", model);
 
 		model.clear();
-		scriptController.delete(getTestUser(), path, "new_file.py");
+		scriptApiController.delete(getTestUser(), path, "new_file.py");
 		scriptController.getAll(getTestUser(), path, model);
 		List<FileEntry> scriptList = (List<FileEntry>) model.get("files");
 		assertThat(scriptList.size(), is(0));
@@ -131,7 +134,7 @@ public class FileEntryControllerTest extends AbstractNGrinderTransactionalTest {
 
 		model.clear();
 		// delete both files
-		scriptController.delete(getTestUser(), path, "file-for-search.py,new-file-for-search.py");
+		scriptApiController.delete(getTestUser(), path, "file-for-search.py,new-file-for-search.py");
 		scriptController.getAll(getTestUser(), path, model);
 		List<FileEntry> scriptList = (List<FileEntry>) model.get("files");
 		assertThat(scriptList.size(), is(0));

--- a/ngrinder-core/build.gradle
+++ b/ngrinder-core/build.gradle
@@ -18,6 +18,8 @@ dependencies {
     compile (group: "org.slf4j", name: "slf4j-api", version: slf4j_version)
     compile (group: "org.slf4j", name: "jcl-over-slf4j", version: slf4j_version)
     compile (group: 'org.hibernate', name: 'hibernate-core', version: hibernate_version)
+    compile (group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: jackson_version)
+
     compile (group: 'org.jboss.spec.javax.transaction', name: 'jboss-transaction-api_1.2_spec', version: '1.0.1.Final')
 
     testCompile (group: "org.easytesting", name: "fest-assert", version:"1.4")

--- a/ngrinder-core/src/main/java/org/ngrinder/model/PerfTest.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/model/PerfTest.java
@@ -345,7 +345,7 @@ public class PerfTest extends BaseModel<PerfTest> {
 
 
 	public String getTestIdentifier() {
-		return "perftest_" + getId() + "_" + getLastModifiedUser().getUserId();
+		return "perftest_" + getId() + "_" + super.getLastModifiedUser().getUserId();
 	}
 
 	/**
@@ -822,5 +822,15 @@ public class PerfTest extends BaseModel<PerfTest> {
 		}
 		this.useRampUp = getSafe(this.useRampUp);
 		this.safeDistribution = getSafe(this.safeDistribution);
+	}
+
+	@Override
+	public User getCreatedUser() {
+		return super.getCreatedUser().getUserBaseInfo();
+	}
+
+	@Override
+	public User getLastModifiedUser() {
+		return super.getLastModifiedUser().getUserBaseInfo();
 	}
 }

--- a/ngrinder-core/src/main/java/org/ngrinder/model/User.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/model/User.java
@@ -13,6 +13,7 @@
  */
 package org.ngrinder.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.gson.annotations.Expose;
 import org.apache.commons.lang.StringUtils;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -282,7 +283,7 @@ public class User extends BaseModel<User> {
 		this.userLanguage = userLanguage;
 	}
 
-	public boolean isExternal() {
+	public Boolean isExternal() {
 		return external;
 	}
 
@@ -330,8 +331,21 @@ public class User extends BaseModel<User> {
 		this.follower = follower;
 	}
 
+	@JsonIgnore
 	public User getFactualUser() {
 		return ownerUser == null ? this : ownerUser;
+	}
+
+	@Override
+	@JsonIgnore
+	public User getCreatedUser() {
+		return super.getCreatedUser();
+	}
+
+	@Override
+	@JsonIgnore
+	public User getLastModifiedUser() {
+		return super.getLastModifiedUser();
 	}
 
 	/**
@@ -341,6 +355,7 @@ public class User extends BaseModel<User> {
 	 */
 	// It will throw StackOverflowException if return User that contains owners and followers value
 	// in getCurrentPerfTestStatistics() method.so just return base User info
+	@JsonIgnore
 	public User getUserBaseInfo() {
 		User userInfo = new User();
 		userInfo.setId(this.getId());


### PR DESCRIPTION
Previously, nGrinder serialize object into json using `gson`.
However, spring support 'jackson' serialization by default.
If we use jackson, codes can be simplified a lot.

* [x] Perftest controller (18)
* [x] AgentManager controller (12)
* [x] MonitorManager controller (2)
* [x] LogMonitor controller (2)
* [x] SystemConfig controller (2)
* [x] FIleEntry controller (7)
* [ ] User controller (9)
* [ ] UserSignUp controller (2)

