### PR TITLE
Set line separator on codemirror depending on OS

### DIFF
--- a/ngrinder-frontend/src/js/components/common/CodeMirror.vue
+++ b/ngrinder-frontend/src/js/components/common/CodeMirror.vue
@@ -50,6 +50,7 @@
                 tabSize: 4,
                 indentWithTabs: true,
                 smartIndent: false,
+                lineSeparator: navigator.platform.includes('Win') ? '\r\n' : '\n',
                 visibleTab: true,
                 readOnly: false,
                 styleActiveLine: true,


### PR DESCRIPTION
Codemirror default line separator is `\n`.
so, `changed()` in `Editor.vue` is aways true in `windows (\r\n)`

https://github.com/naver/ngrinder/blob/feature/convert-to-vuejs/ngrinder-frontend/src/js/components/script/Editor.vue#L280

 to solve this, set codemirror line separator depending on OS.