### PR TITLE
Enable saving scripts when running ngrinder-controller with context path

### DIFF
--- a/ngrinder-controller/pom.xml
+++ b/ngrinder-controller/pom.xml
@@ -342,7 +342,7 @@
 			<artifactId>gson</artifactId>
 			<version>2.2</version>
 		</dependency>
-	
+
 		<dependency>
 			<groupId>jaxen</groupId>
 			<artifactId>jaxen</artifactId>
@@ -409,7 +409,7 @@
 			<artifactId>pf4j</artifactId>
 			<version>0.12.0</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>ro.fortsoft.pf4j</groupId>
 			<artifactId>pf4j-spring</artifactId>
@@ -435,7 +435,7 @@
 		<dependency>
 			<groupId>com.navercorp.lucy</groupId>
 			<artifactId>lucy-xss-servlet</artifactId>
-			<version>2.0.0</version>
+			<version>2.0.1</version>
 		</dependency>
 	</dependencies>
 

--- a/ngrinder-controller/src/main/webapp/WEB-INF/ftl/script/editor.ftl
+++ b/ngrinder-controller/src/main/webapp/WEB-INF/ftl/script/editor.ftl
@@ -113,8 +113,8 @@
 		</form>
 
 
-		<textarea id="codemirror_content">${((file.content)!"")?replace("&para", "&amp;para")}</textarea>
-		<textarea id="old_content" class="hidden">${((file.content)!"")?replace("&para", "&amp;para")}</textarea>
+		<textarea id="codemirror_content">${((file.content)!"")?replace("&", "&amp;")}</textarea>
+		<textarea id="old_content" class="hidden">${((file.content)!"")?replace("&", "&amp;")}</textarea>
 		<div class="pull-right" rel="popover" style="float;margin-top:-20px;margin-right:-30px;cursor: pointer"
 			title="Tip" data-html="ture"
 			data-placement="left"


### PR DESCRIPTION
- Resolve #389 issue.
- New version of lucy xss servlet filter works fine with context path.
- Script editor shows unescaped html (#385)