### PR TITLE
Apply URL decoding when getting file name from URLClassLoader

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/agent/service/AgentPackageService.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/agent/service/AgentPackageService.java
@@ -5,7 +5,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.ngrinder.infra.config.Config;
 import org.ngrinder.packages.AgentPackageHandler;
-import org.ngrinder.packages.MonitorPackageHandler;
 import org.ngrinder.packages.PackageHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,6 +21,7 @@ import java.util.zip.ZipFile;
 
 import static org.apache.commons.lang.StringUtils.isNotEmpty;
 import static org.ngrinder.common.util.CompressionUtils.*;
+import static org.ngrinder.common.util.EncodingUtils.decodePathWithUTF8;
 
 /**
  * Agent package service.
@@ -96,7 +96,7 @@ public class AgentPackageService {
 		packageHandler.copyShellFile(tarOutputStream);
 
 		for (URL eachUrl : classLoader.getURLs()) {
-			File eachClassPath = new File(eachUrl.getFile());
+			File eachClassPath = new File(decodePathWithUTF8(eachUrl.getFile()));
 			if (!isJar(eachClassPath)) {
 				continue;
 			}

--- a/ngrinder-controller/src/main/java/org/ngrinder/common/model/Home.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/common/model/Home.java
@@ -27,7 +27,6 @@ import org.springframework.core.io.Resource;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
-import java.net.URLClassLoader;
 import java.util.Properties;
 
 import static org.ngrinder.common.util.ExceptionUtils.processException;

--- a/ngrinder-controller/src/main/java/org/ngrinder/common/util/EncodingUtils.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/common/util/EncodingUtils.java
@@ -15,13 +15,14 @@ package org.ngrinder.common.util;
 
 import com.ibm.icu.text.CharsetDetector;
 import com.ibm.icu.text.CharsetMatch;
-import org.apache.commons.lang.StringUtils;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.ngrinder.common.util.ExceptionUtils.processException;
 
 /**
@@ -87,6 +88,20 @@ public abstract class EncodingUtils {
 				}
 			}
 			return result.toString();
+		} catch (UnsupportedEncodingException e) {
+			throw processException(e);
+		}
+	}
+
+	/**
+	 * Decode the given path with UTF-8.
+	 *
+	 * @param path path
+	 * @return decoded path
+	 */
+	public static String decodePathWithUTF8(String path) {
+		try {
+			return URLDecoder.decode(path, UTF_8.name());
 		} catch (UnsupportedEncodingException e) {
 			throw processException(e);
 		}

--- a/ngrinder-controller/src/main/java/org/ngrinder/script/controller/FileEntryController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/script/controller/FileEntryController.java
@@ -20,7 +20,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.ngrinder.common.controller.BaseController;
 import org.ngrinder.common.controller.RestAPI;
-import org.ngrinder.common.util.EncodingUtils;
 import org.ngrinder.common.util.HttpContainerContext;
 import org.ngrinder.common.util.PathUtils;
 import org.ngrinder.common.util.UrlUtils;

--- a/ngrinder-core/src/main/java/net/grinder/engine/agent/LocalScriptTestDriveService.java
+++ b/ngrinder-core/src/main/java/net/grinder/engine/agent/LocalScriptTestDriveService.java
@@ -34,6 +34,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Properties;
 
+import static org.ngrinder.common.util.EncodingUtils.decodePathWithUTF8;
 import static org.ngrinder.common.util.NoOp.noOp;
 
 /**
@@ -43,7 +44,6 @@ import static org.ngrinder.common.util.NoOp.noOp;
  * in ngrinder-core is... some The Grinder core class doesn't have public
  * access..
  *
- * @author JunHo Yoon
  * @since 3.0
  */
 public class LocalScriptTestDriveService {
@@ -241,7 +241,7 @@ public class LocalScriptTestDriveService {
 		StringBuilder runtimeClassPath = new StringBuilder();
 		for (URL url : ((URLClassLoader) LocalScriptTestDriveService.class.getClassLoader()).getURLs()) {
 			if (url.getPath().contains("ngrinder-runtime") || url.getPath().contains("ngrinder-groovy")) {
-				runtimeClassPath.append(url.getFile()).append(File.pathSeparator);
+				runtimeClassPath.append(decodePathWithUTF8(url.getFile())).append(File.pathSeparator);
 			}
 		}
 		return runtimeClassPath.toString();

--- a/ngrinder-core/src/main/java/net/grinder/util/AbstractGrinderClassPathProcessor.java
+++ b/ngrinder-core/src/main/java/net/grinder/util/AbstractGrinderClassPathProcessor.java
@@ -13,8 +13,9 @@
  */
 package net.grinder.util;
 
-import static org.ngrinder.common.util.CollectionUtils.newArrayList;
-import static org.ngrinder.common.util.Preconditions.checkNotNull;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
 
 import java.io.File;
 import java.net.URL;
@@ -22,9 +23,9 @@ import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang.StringUtils;
-import org.slf4j.Logger;
+import static org.ngrinder.common.util.CollectionUtils.newArrayList;
+import static org.ngrinder.common.util.EncodingUtils.decodePathWithUTF8;
+import static org.ngrinder.common.util.Preconditions.checkNotNull;
 
 /**
  * Grinder classpath optimization class.
@@ -211,7 +212,7 @@ public abstract class AbstractGrinderClassPathProcessor {
 		URL[] urLs = ((URLClassLoader) AbstractGrinderClassPathProcessor.class.getClassLoader()).getURLs();
 		StringBuilder builder = new StringBuilder();
 		for (URL each : urLs) {
-			builder.append(each.getFile()).append(File.pathSeparator);
+			builder.append(decodePathWithUTF8(each.getFile())).append(File.pathSeparator);
 		}
 		return filterForeMostClassPath(builder.toString(), logger);
 	}
@@ -226,7 +227,7 @@ public abstract class AbstractGrinderClassPathProcessor {
 		URL[] urLs = ((URLClassLoader) AbstractGrinderClassPathProcessor.class.getClassLoader()).getURLs();
 		StringBuilder builder = new StringBuilder();
 		for (URL each : urLs) {
-			builder.append(each.getFile()).append(File.pathSeparator);
+			builder.append(decodePathWithUTF8(each.getFile())).append(File.pathSeparator);
 		}
 		return filterPatchClassPath(builder.toString(), logger);
 	}
@@ -242,7 +243,7 @@ public abstract class AbstractGrinderClassPathProcessor {
 
 		StringBuilder builder = new StringBuilder();
 		for (URL each : urls) {
-			builder.append(each.getFile()).append(File.pathSeparator);
+			builder.append(decodePathWithUTF8(each.getFile())).append(File.pathSeparator);
 		}
 		if (builder.length() < 300) {
 			// In case of the URLClassLoader is not activated, Try with system class path

--- a/ngrinder-core/src/main/java/org/ngrinder/common/util/EncodingUtils.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/common/util/EncodingUtils.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ngrinder.common.util;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.ngrinder.common.util.ExceptionUtils.processException;
+
+/**
+ * Automatic encoding detection utility.
+ *
+ * @since 3.5.0
+ */
+public abstract class EncodingUtils {
+
+	/**
+	 * Decode the given path with UTF-8.
+	 *
+	 * @param path path
+	 * @return decoded path
+	 */
+	public static String decodePathWithUTF8(String path) {
+		try {
+			return URLDecoder.decode(path, UTF_8.name());
+		} catch (UnsupportedEncodingException e) {
+			throw processException(e);
+		}
+	}
+}

--- a/ngrinder-core/src/main/java/org/ngrinder/infra/ArchLoaderInit.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/infra/ArchLoaderInit.java
@@ -13,10 +13,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.net.URLDecoder;
 import java.util.Enumeration;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+
+import static org.ngrinder.common.util.EncodingUtils.decodePathWithUTF8;
 
 /**
  * ArchLoader initializer
@@ -73,7 +74,7 @@ public class ArchLoaderInit {
 		final ClassLoader classLoader = ArchLoaderInit.class.getClassLoader();
 		for (URL each : ((URLClassLoader) classLoader).getURLs()) {
 			if (each.getFile().contains("sigar-native-")) {
-				return URLDecoder.decode(each.getFile(), "UTF-8");
+				return decodePathWithUTF8(each.getFile());
 			}
 		}
 
@@ -82,7 +83,7 @@ public class ArchLoaderInit {
 		if (parent != null) {
 			for (URL each : ((URLClassLoader) parent).getURLs()) {
 				if (each.getFile().contains("sigar-native-")) {
-					return URLDecoder.decode(each.getFile(), "UTF-8");
+					return decodePathWithUTF8(each.getFile());
 				}
 			}
 		}


### PR DESCRIPTION
#446

File couldn't be found if there were certain characters in the path when getting the file name from `URL` object (from a URLClassLoader). so apply URL decoding to file name.


#### completed test case
* [x] Download agent
* [x] Download monitor
* [x] Test running with monitor and plugins (using network overflow plugin)
* [x] Script CRUD