### PR TITLE
Use COPY instead of ADD in Dockerfile

### DIFF
--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -12,7 +12,7 @@ ENV BASE_DIR=/opt \
 VOLUME $NGRINDER_AGENT_BASE
 
 # Copy initial execution script
-ADD scripts /scripts
+COPY scripts /scripts
 
 # Excution
 ENTRYPOINT ["/scripts/run.sh"]

--- a/docker/controller/Dockerfile
+++ b/docker/controller/Dockerfile
@@ -14,10 +14,10 @@ EXPOSE 80 16001 12000-12009
 VOLUME $NGRINDER_HOME
 
 # Copy initial execution script
-ADD scripts /scripts
+COPY scripts /scripts
 
 # Copy final binary
-ADD binary/*.war ${BASE_DIR}
+COPY binary/*.war ${BASE_DIR}
 
 # Execution
 CMD ["/scripts/run.sh"]


### PR DESCRIPTION
Hello,

The use of COPY is preferred over ADD when additional functionalities of ADD are not being used (like spraying the contents of a tar in a folder).

Ref: https://docs.docker.com/engine/articles/dockerfile_best-practices/#add-or-copy

Thanks.