### PR TITLE
Exclude global attributes settings to api-controller

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/agent/controller/AgentManagerController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/agent/controller/AgentManagerController.java
@@ -13,6 +13,7 @@
  */
 package org.ngrinder.agent.controller;
 
+import org.ngrinder.common.controller.annotation.GlobalControllerModel;
 import org.ngrinder.model.User;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
  */
 @Controller
 @RequestMapping("/agent")
+@GlobalControllerModel
 @PreAuthorize("hasAnyRole('A', 'S')")
 public class AgentManagerController {
 

--- a/ngrinder-controller/src/main/java/org/ngrinder/common/controller/GlobalControllerAdvice.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/common/controller/GlobalControllerAdvice.java
@@ -1,6 +1,7 @@
 package org.ngrinder.common.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.ngrinder.common.controller.annotation.GlobalControllerModel;
 import org.ngrinder.infra.config.Config;
 import org.ngrinder.operation.service.AnnouncementService;
 import org.ngrinder.perftest.service.PerfTestService;
@@ -18,9 +19,9 @@ import static org.ngrinder.common.util.NoOp.noOp;
 /**
  * Includes common model attributes. These attributes uses in app.html
  *
- * @since 3.5
+ * @since 3.5.0
  */
-@ControllerAdvice
+@ControllerAdvice(annotations = GlobalControllerModel.class)
 @RequiredArgsConstructor
 public class GlobalControllerAdvice {
 

--- a/ngrinder-controller/src/main/java/org/ngrinder/common/controller/annotation/GlobalControllerModel.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/common/controller/annotation/GlobalControllerModel.java
@@ -1,0 +1,14 @@
+package org.ngrinder.common.controller.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Annotation which marks the required global model attributes.
+ *
+ * @since 3.5.0
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface GlobalControllerModel {
+}

--- a/ngrinder-controller/src/main/java/org/ngrinder/home/controller/HealthCheckApiController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/home/controller/HealthCheckApiController.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ngrinder.home.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.ngrinder.common.constant.ControllerConstants;
+import org.ngrinder.common.controller.annotation.GlobalControllerModel;
+import org.ngrinder.common.util.ThreadUtils;
+import org.ngrinder.infra.config.Config;
+import org.ngrinder.region.service.RegionService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Health check api controller.
+ *
+ * @since 3.5.0
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class HealthCheckApiController implements ControllerConstants {
+
+	private final RegionService regionService;
+
+	private final Config config;
+
+	/**
+	 * Return the health check message. If there is shutdown lock, it returns
+	 * 503. Otherwise it returns region lists.
+	 *
+	 * @param response response
+	 * @return region list
+	 */
+	@GetMapping("/check/healthcheck")
+	public Map<String, Object> healthCheck(HttpServletResponse response) {
+		if (config.hasShutdownLock()) {
+			try {
+				response.sendError(503, "nGrinder is about to down");
+			} catch (IOException e) {
+				log.error("While running healthCheck() in HomeController, the error occurs.");
+				log.error("Details : ", e);
+			}
+		}
+		Map<String, Object> map = new HashMap<>();
+		map.put("current", regionService.getCurrent());
+		map.put("regions", regionService.getAll());
+		return map;
+	}
+
+	/**
+	 * Return health check message with 1 sec delay. If there is shutdown lock,
+	 * it returns 503. Otherwise, it returns region lists.
+	 *
+	 * @param sleep    in milliseconds.
+	 * @param response response
+	 * @return region list
+	 */
+	@GetMapping("/check/healthcheck_slow")
+	public Map<String, Object> healthCheckSlowly(@RequestParam(value = "delay", defaultValue = "1000") int sleep,
+												HttpServletResponse response) {
+		ThreadUtils.sleep(sleep);
+		return healthCheck(response);
+	}
+}

--- a/ngrinder-controller/src/main/java/org/ngrinder/home/controller/HomeController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/home/controller/HomeController.java
@@ -15,6 +15,7 @@ package org.ngrinder.home.controller;
 
 import org.apache.commons.lang.StringUtils;
 import org.ngrinder.common.constant.ControllerConstants;
+import org.ngrinder.common.controller.annotation.GlobalControllerModel;
 import org.ngrinder.common.util.ThreadUtils;
 import org.ngrinder.infra.config.Config;
 import org.ngrinder.infra.logger.CoreLogger;
@@ -52,6 +53,7 @@ import lombok.RequiredArgsConstructor;
  * @since 3.0
  */
 @Controller
+@GlobalControllerModel
 @RequiredArgsConstructor
 public class HomeController implements ControllerConstants {
 
@@ -181,5 +183,4 @@ public class HomeController implements ControllerConstants {
 		model.clear();
 		return "app";
 	}
-
 }

--- a/ngrinder-controller/src/main/java/org/ngrinder/home/controller/HomeController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/home/controller/HomeController.java
@@ -13,35 +13,28 @@
  */
 package org.ngrinder.home.controller;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.ngrinder.common.constant.ControllerConstants;
 import org.ngrinder.common.controller.annotation.GlobalControllerModel;
-import org.ngrinder.common.util.ThreadUtils;
 import org.ngrinder.infra.config.Config;
 import org.ngrinder.infra.logger.CoreLogger;
 import org.ngrinder.model.Role;
 import org.ngrinder.model.User;
-import org.ngrinder.region.service.RegionService;
 import org.ngrinder.script.handler.ScriptHandlerFactory;
 import org.ngrinder.user.service.UserContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.propertyeditors.LocaleEditor;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.LocaleResolver;
 import org.springframework.web.servlet.support.RequestContextUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.HashMap;
 import java.util.Locale;
-import java.util.Map;
 
 import static org.ngrinder.common.util.Preconditions.checkNotNull;
 
@@ -52,14 +45,11 @@ import lombok.RequiredArgsConstructor;
  *
  * @since 3.0
  */
+@Slf4j
 @Controller
 @GlobalControllerModel
 @RequiredArgsConstructor
 public class HomeController implements ControllerConstants {
-
-	private static final Logger LOG = LoggerFactory.getLogger(HomeController.class);
-
-	private final RegionService regionService;
 
 	private final ScriptHandlerFactory scriptHandlerFactory;
 
@@ -100,7 +90,7 @@ public class HomeController implements ControllerConstants {
 			if (role == Role.ADMIN || role == Role.SUPER_USER || role == Role.USER) {
 				return "app";
 			} else {
-				LOG.info("Invalid user role:{}", role.getFullName());
+				log.info("Invalid user role:{}", role.getFullName());
 				return "app";
 			}
 		} catch (Exception e) {
@@ -114,46 +104,6 @@ public class HomeController implements ControllerConstants {
 		if (StringUtils.isNotEmpty(region)) {
 			CoreLogger.LOGGER.info("Accessed to {}", region);
 		}
-	}
-
-	/**
-	 * Return the health check message. If there is shutdown lock, it returns
-	 * 503. Otherwise it returns region lists.
-	 *
-	 * @param response response
-	 * @return region list
-	 */
-	@ResponseBody
-	@GetMapping("/check/healthcheck")
-	public Map<String, Object> healthCheck(HttpServletResponse response) {
-		if (config.hasShutdownLock()) {
-			try {
-				response.sendError(503, "nGrinder is about to down");
-			} catch (IOException e) {
-				LOG.error("While running healthCheck() in HomeController, the error occurs.");
-				LOG.error("Details : ", e);
-			}
-		}
-		Map<String, Object> map = new HashMap<>();
-		map.put("current", regionService.getCurrent());
-		map.put("regions", regionService.getAll());
-		return map;
-	}
-
-	/**
-	 * Return health check message with 1 sec delay. If there is shutdown lock,
-	 * it returns 503. Otherwise, it returns region lists.
-	 *
-	 * @param sleep    in milliseconds.
-	 * @param response response
-	 * @return region list
-	 */
-	@ResponseBody
-	@GetMapping("/check/healthcheck_slow")
-	public Map<String, Object> healthCheckSlowly(@RequestParam(value = "delay", defaultValue = "1000") int sleep,
-												HttpServletResponse response) {
-		ThreadUtils.sleep(sleep);
-		return healthCheck(response);
 	}
 
 	private void setLanguage(String lan, HttpServletResponse response, HttpServletRequest request) {

--- a/ngrinder-controller/src/main/java/org/ngrinder/operation/cotroller/AnnouncementController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/operation/cotroller/AnnouncementController.java
@@ -13,6 +13,7 @@
  */
 package org.ngrinder.operation.cotroller;
 
+import org.ngrinder.common.controller.annotation.GlobalControllerModel;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.*;
  */
 @Controller
 @RequestMapping("/operation/announcement")
+@GlobalControllerModel
 @PreAuthorize("hasAnyRole('A', 'S')")
 public class AnnouncementController {
 

--- a/ngrinder-controller/src/main/java/org/ngrinder/operation/cotroller/ScriptConsoleController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/operation/cotroller/ScriptConsoleController.java
@@ -13,6 +13,7 @@
  */
 package org.ngrinder.operation.cotroller;
 
+import org.ngrinder.common.controller.annotation.GlobalControllerModel;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @Profile("production")
 @Controller
 @RequestMapping("/operation/script_console")
+@GlobalControllerModel
 @PreAuthorize("hasAnyRole('A')")
 public class ScriptConsoleController {
 

--- a/ngrinder-controller/src/main/java/org/ngrinder/operation/cotroller/SystemConfigController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/operation/cotroller/SystemConfigController.java
@@ -13,6 +13,7 @@
  */
 package org.ngrinder.operation.cotroller;
 
+import org.ngrinder.common.controller.annotation.GlobalControllerModel;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
  */
 @Controller
 @RequestMapping("/operation/system_config")
+@GlobalControllerModel
 @PreAuthorize("hasAnyRole('A')")
 public class SystemConfigController {
 

--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/controller/PerfTestController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/controller/PerfTestController.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import net.grinder.util.LogCompressUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
+import org.ngrinder.common.controller.annotation.GlobalControllerModel;
 import org.ngrinder.common.util.FileDownloadUtils;
 import org.ngrinder.infra.logger.CoreLogger;
 import org.ngrinder.infra.spring.RemainedPath;
@@ -40,6 +41,7 @@ import static org.ngrinder.common.util.Preconditions.*;
  */
 @Controller
 @RequestMapping("/perftest")
+@GlobalControllerModel
 @RequiredArgsConstructor
 public class PerfTestController {
 

--- a/ngrinder-controller/src/main/java/org/ngrinder/script/controller/FileEntryController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/script/controller/FileEntryController.java
@@ -15,6 +15,7 @@ package org.ngrinder.script.controller;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
+import org.ngrinder.common.controller.annotation.GlobalControllerModel;
 import org.ngrinder.infra.spring.RemainedPath;
 import org.ngrinder.model.User;
 import org.ngrinder.script.model.FileEntry;
@@ -39,6 +40,7 @@ import lombok.RequiredArgsConstructor;
  */
 @Controller
 @RequestMapping("/script")
+@GlobalControllerModel
 @RequiredArgsConstructor
 public class FileEntryController {
 

--- a/ngrinder-controller/src/main/java/org/ngrinder/user/controller/UserController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/user/controller/UserController.java
@@ -14,6 +14,7 @@
 package org.ngrinder.user.controller;
 
 import org.apache.commons.lang.StringUtils;
+import org.ngrinder.common.controller.annotation.GlobalControllerModel;
 import org.ngrinder.model.User;
 import org.ngrinder.user.service.UserService;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -33,6 +34,7 @@ import lombok.RequiredArgsConstructor;
  */
 @Controller
 @RequestMapping("/user")
+@GlobalControllerModel
 @RequiredArgsConstructor
 public class UserController {
 

--- a/ngrinder-controller/src/test/java/org/ngrinder/home/controller/HomeControllerTest.java
+++ b/ngrinder-controller/src/test/java/org/ngrinder/home/controller/HomeControllerTest.java
@@ -38,6 +38,9 @@ public class HomeControllerTest extends AbstractNGrinderTransactionalTest {
 	private HomeController homeController;
 
 	@Autowired
+	private HealthCheckApiController healthCheckApiController;
+
+	@Autowired
 	private RegionService regionService;
 
 	@Test
@@ -62,8 +65,8 @@ public class HomeControllerTest extends AbstractNGrinderTransactionalTest {
 	@Test
 	public void testHealthCheck() {
 		MockHttpServletResponse res = new MockHttpServletResponse();
-		homeController.healthCheck(res);
-		Map<String, Object> message = homeController.healthCheckSlowly(500, res);
+		healthCheckApiController.healthCheck(res);
+		Map<String, Object> message = healthCheckApiController.healthCheckSlowly(500, res);
 		assertEquals(message.get("current"), regionService.getCurrent());
 	}
 


### PR DESCRIPTION
Make `GlobalControllerAdvice` work only on controller that return view (app.html)
> exclude api-controller, download controller