### PR TITLE
Apply scroll to popover contents

### DIFF
--- a/ngrinder-frontend/src/js/components/Base.vue
+++ b/ngrinder-frontend/src/js/components/Base.vue
@@ -200,7 +200,9 @@
             font-size: 12px;
 
             .popover-body {
+                max-height: 450px;
                 line-height: 20px;
+                overflow-y: scroll;
             }
         }
 

--- a/ngrinder-frontend/src/js/components/common/mixin/PopoverMixin.vue
+++ b/ngrinder-frontend/src/js/components/common/mixin/PopoverMixin.vue
@@ -1,0 +1,23 @@
+<script>
+    import { Mixin } from 'vue-mixin-decorator';
+
+    @Mixin
+    export default class PopoverMixin {
+        initPopover($popover) {
+            $popover
+                .popover()
+                .unbind()
+                .on('mouseenter', function () {
+                    $(this).popover('show');
+                    $('.popover').on('mouseleave', () => $(this).popover('hide'));
+                })
+                .on('mouseleave', function () {
+                    setTimeout(() => {
+                        if (!$('.popover:hover').length) {
+                            $(this).popover('hide');
+                        }
+                    }, 50);
+                });
+        }
+    }
+</script>

--- a/ngrinder-frontend/src/js/components/perftest/detail/Detail.vue
+++ b/ngrinder-frontend/src/js/components/perftest/detail/Detail.vue
@@ -104,6 +104,7 @@
     import Select2 from '../../common/Select2.vue';
     import ScheduleModal from '../modal/ScheduleModal.vue';
     import MessagesMixin from '../../common/mixin/MessagesMixin.vue';
+    import PopoverMixin from '../../common/mixin/PopoverMixin.vue';
 
     class PerfTestSerializer {
         static serialize(test) {
@@ -189,7 +190,7 @@
             validator: 'new',
         },
     })
-    export default class PerfTestDetail extends Mixins(Base, MessagesMixin) {
+    export default class PerfTestDetail extends Mixins(Base, MessagesMixin, PopoverMixin) {
         @Prop({ type: String, required: false })
         id;
 
@@ -281,7 +282,8 @@
                 this.$testStatusImage = $(this.$refs.testStatusImage);
                 this.$testStatusImage.attr('data-content', `${this.test.progressMessage}<br><b>${this.test.lastProgressMessage}</b>`.replace(/\n/g, '<br>'));
                 this.currentRefreshStatusTimeoutId = this.refreshPerftestStatus();
-                $('[data-toggle="popover"]').popover();
+
+                this.initPopover($('[data-toggle="popover"]'));
                 this.setTabEvent();
                 this.updateTabDisplay();
             });

--- a/ngrinder-frontend/src/js/components/perftest/list/List.vue
+++ b/ngrinder-frontend/src/js/components/perftest/list/List.vue
@@ -149,6 +149,7 @@
     import SearchBar from './Searchbar.vue';
     import IntroButton from '../../common/IntroButton.vue';
     import MessagesMixin from '../../common/mixin/MessagesMixin.vue';
+    import PopoverMixin from '../../common/mixin/PopoverMixin.vue';
     import SmallChart from './SmallChart.vue';
     import TableConfig from './mixin/TableConfig.vue';
 
@@ -158,7 +159,7 @@
         name: 'perfTestList',
         components: { IntroButton, vueHeadful, SearchBar, Vuetable, VuetablePagination },
     })
-    export default class PerfTestList extends Mixins(Base, MessagesMixin, TableConfig) {
+    export default class PerfTestList extends Mixins(Base, MessagesMixin, TableConfig, PopoverMixin) {
         runningSummary = `0 ${this.i18n('perfTest.list.runningSummary')}`;
         tests = [];
         autoUpdateTargets = [];
@@ -249,8 +250,9 @@
                 }
             });
             this.$nextTick(() => {
-                $('[data-toggle="popover"]').popover('dispose');
-                $('[data-toggle="popover"]').popover();
+                const $popover = $('[data-toggle="popover"]');
+                $popover.popover('dispose');
+                this.initPopover($popover);
             });
         }
 
@@ -439,7 +441,6 @@
             width: auto;
             min-width: 200px;
             max-width: 600px;
-            max-height: 500px;
         }
     }
 


### PR DESCRIPTION
## Problem
If test have many distribution files, It couldn't view the popover contents and make flickering.

![image](https://user-images.githubusercontent.com/14273601/76220051-270d8e80-625a-11ea-9f15-e8ec962e6e85.png)

## Solution
Apply scroll to popover contents.
(popover alive while being hovered)

![image](https://user-images.githubusercontent.com/14273601/76220321-9edbb900-625a-11ea-953c-3b075cdb523e.png)
