### PR TITLE
Add maven publishing task to gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ allprojects  {
 
 subprojects {
   apply plugin: "java"
+  apply plugin: "maven-publish"
 
   compileJava.options.encoding = "UTF-8"
   compileTestJava.options.encoding = "UTF-8"
@@ -47,5 +48,30 @@ subprojects {
 
   test {
     testLogging.showStandardStreams = true
+  }
+
+  task javadocJar(type: Jar) {
+    from javadoc.destinationDir
+    classifier "javadoc"
+  }
+
+  task sourceJar(type: Jar) {
+    from sourceSets.main.allJava
+    classifier "sources"
+  }
+
+  publishing {
+    publications {
+      nGrinerModules(MavenPublication) {
+        from components.java
+        artifact sourceJar
+        artifact javadocJar
+      }
+    }
+    repositories {
+      maven {
+        url = "file:../../ngrinder.maven.repo/releases/"
+      }
+    }
   }
 }


### PR DESCRIPTION
Add gradle task for publishing ngrinder artifact.

For testing, I deployed the artifact that published with gradle to [`ngrinder.maven.repo.test`](https://github.com/naver/ngrinder/tree/ngrinder.maven.repo.test/releases/org/ngrinder/ngrinder-core/3.5.0) branch.

* [x] Is groovy maven script working?
* [x] Is script run in IDE using `ngrinder-groovy`?