### PR TITLE
Support multi user defined data type

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/controller/PerfTestApiController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/controller/PerfTestApiController.java
@@ -637,9 +637,8 @@ public class PerfTestApiController {
 		int interval = perfTestService.getReportDataInterval(id, dataTypes[0], imgWidth);
 		Map<String, Object> resultMap = Maps.newHashMap();
 		for (String each : dataTypes) {
-			String key = StringUtils.replaceChars(each, "()", "");
 			Map<String, List<Float>> result = perfTestService.getReportData(id, each, onlyTotal, interval);
-			resultMap.put(key, result);
+			resultMap.put(each, result);
 		}
 		resultMap.put(PARAM_TEST_CHART_INTERVAL, interval * test.getSamplingInterval());
 		return resultMap;

--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/PerfTestService.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/PerfTestService.java
@@ -75,6 +75,9 @@ import java.util.Map.Entry;
 import static java.lang.Long.valueOf;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.io.FileUtils.deleteQuietly;
+import static java.util.Arrays.asList;
+import static net.grinder.SingleConsole.REPORT_DATA;
+import static org.apache.commons.io.FilenameUtils.removeExtension;
 import static org.ngrinder.common.constant.CacheConstants.*;
 import static org.ngrinder.common.constants.MonitorConstants.MONITOR_FILE_PREFIX;
 import static org.ngrinder.common.util.AccessUtils.getSafe;
@@ -100,8 +103,6 @@ public class PerfTestService extends AbstractPerfTestService implements Controll
 	private static final int MAX_POINT_COUNT = 100;
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(PerfTestService.class);
-
-	private static final String DATA_FILE_EXTENSION = ".data";
 
 	private static final String NULL_STRING = "null";
 	private static final String UNDEFINED_STRING = "undefined";
@@ -746,7 +747,7 @@ public class PerfTestService extends AbstractPerfTestService implements Controll
 		int pointCount = Math.max(imgWidth, MAX_POINT_COUNT);
 		File reportFolder = config.getHome().getPerfTestReportDirectory(String.valueOf(testId));
 		int interval = 0;
-		File targetFile = new File(reportFolder, dataType + DATA_FILE_EXTENSION);
+		File targetFile = new File(reportFolder, dataType + REPORT_DATA);
 		if (!targetFile.exists()) {
 			LOGGER.warn("Report {} for test {} does not exist.", dataType, testId);
 			return 0;
@@ -827,7 +828,7 @@ public class PerfTestService extends AbstractPerfTestService implements Controll
 		if (!logFileDirectory.exists() || !logFileDirectory.isDirectory()) {
 			return Collections.emptyList();
 		}
-		return Arrays.asList(logFileDirectory.list());
+		return asList(logFileDirectory.list());
 	}
 
 	/**
@@ -1437,33 +1438,12 @@ public class PerfTestService extends AbstractPerfTestService implements Controll
 	 * @return list containing label and tps value list
 	 */
 	public Map<String, List<Float>> getReportData(long testId, String key, boolean onlyTotal, int interval) {
-		Map<String, List<Float>> resultMap = new HashMap<>();
+		Map<String, List<Float>> resultMap = new TreeMap<>();
 		List<File> reportDataFiles = onlyTotal ? Lists.newArrayList(getReportDataFile(testId, key)) : getReportDataFiles(testId, key);
-		reportDataFiles.forEach(each -> {
-			String reportName = buildReportName(key, each);
-			if (key.equals(reportName)) {
-				reportName = "Total";
-			} else {
-				reportName = reportName.replace("_", " ");
-			}
-
-			resultMap.put(reportName, getFileDataAsList(each, interval));
-		});
-
+		reportDataFiles.forEach(each -> resultMap.put(removeExtension(each.getName()), getFileDataAsList(each, interval)));
 		return resultMap;
 	}
 
-	private String buildReportName(String key, File file) {
-		String reportName = FilenameUtils.removeExtension(file.getName());
-		if (key.equals(reportName)) {
-			return reportName;
-		}
-		String[] baseName = StringUtils.split(reportName, "-", 2);
-		if (SingleConsole.INTERESTING_PER_TEST_STATISTICS.contains(baseName[0]) && baseName.length >= 2) {
-			reportName = baseName[1];
-		}
-		return reportName;
-	}
 	/**
 	 * Get a single file for the given report key.
 	 *

--- a/ngrinder-frontend/src/js/components/common/mixin/ChartMixin.vue
+++ b/ngrinder-frontend/src/js/components/common/mixin/ChartMixin.vue
@@ -119,6 +119,48 @@
                 return timeSeries;
             }
         }
+
+        processData(data, dataType) {
+            let result = {};
+            Object.entries(data).forEach(([key, value]) => {
+                if (dataType === key) {
+                    result['Total'] = value;
+                    return true;
+                }
+                result[this.getTestDesc(dataType, key)] = value;
+            });
+            return result;
+        }
+
+        processUserDefinedData(userDefinedData, numOfTestRecord) {
+            let dataType;
+            let userDefinedDataTemp;
+            let result = [];
+
+            Object.entries(userDefinedData).forEach(([key, value], index) => {
+                if (index % numOfTestRecord === 0) {
+                    dataType = key;
+                    userDefinedDataTemp = { title: this.getUserDefinedChartTitle(key), data: {}, };
+                    userDefinedDataTemp.data['Total'] = value;
+                    result[index/numOfTestRecord] = userDefinedDataTemp;
+                } else {
+                    userDefinedDataTemp.data[this.getTestDesc(dataType, key)] = value;
+                }
+            });
+            return result;
+        }
+
+        getUserDefinedChartTitle(dataType) {
+            const title = dataType.replace(/User_defined|_/g, ' ').trim();
+            return title ? title : this.i18n('perfTest.report.header.userDefinedChart');
+        }
+
+        getTestDesc(dataType, dataFileName) {
+            dataFileName = dataFileName.replace(dataType, '');
+            return dataFileName.substring(dataFileName.indexOf('_') + 1)
+                .replace(/_/g, ' ')
+                .trim();
+        }
     }
 </script>
 

--- a/ngrinder-frontend/src/js/components/perftest/list/SmallChart.vue
+++ b/ngrinder-frontend/src/js/components/perftest/list/SmallChart.vue
@@ -10,6 +10,7 @@
 </template>
 
 <script>
+    import { Mixins } from 'vue-mixin-decorator';
     import Component from 'vue-class-component';
     import bb from 'billboard.js';
 
@@ -81,7 +82,7 @@
             },
         },
     })
-    export default class SmallChart extends Base {
+    export default class SmallChart extends Mixins(Base, ChartMixin) {
         created() {
             this.showChart();
         }
@@ -93,16 +94,21 @@
                     imgWidth: 100,
                     onlyTotal: true,
                 },
-            }).then(res => this.initCharts(res.data));
+            }).then(res => {
+                Object.entries(res.data).forEach(([key, value]) => {
+                    res.data[key] = this.processData(value, key);
+                });
+                this.initCharts(res.data);
+            });
         }
 
         initCharts(data) {
-            const interval = data.chartInterval;
+            const interval = data['chartInterval'];
 
-            this.drawSmallChart(`tps_${this.rowData.id}`, 'TPS', data.TPS.Total, interval);
-            this.drawSmallChart(`mtt_${this.rowData.id}`, 'MTT', data.Mean_Test_Time_ms.Total, interval);
-            this.drawSmallChart(`mttfb_${this.rowData.id}`, 'MTTFB', data.Mean_time_to_first_byte.Total, interval);
-            this.drawSmallChart(`err_${this.rowData.id}`, 'ERR', data.Errors.Total, interval);
+            this.drawSmallChart(`tps_${this.rowData.id}`, 'TPS', data['TPS'].Total, interval);
+            this.drawSmallChart(`mtt_${this.rowData.id}`, 'MTT', data['Mean_Test_Time_(ms)'].Total, interval);
+            this.drawSmallChart(`mttfb_${this.rowData.id}`, 'MTTFB', data['Mean_time_to_first_byte'].Total, interval);
+            this.drawSmallChart(`err_${this.rowData.id}`, 'ERR', data['Errors'].Total, interval);
 
             this.$nextTick(() => {
                 $('g.bb-axis.bb-axis-x text[style*="display: none;"]').siblings().css({ display: 'none' });


### PR DESCRIPTION
Support multi user defined data type.

```
// sample
grinder.statistics.registerSummaryExpression("User_defined", "(/ userLong0(+ (count timedTests)))")
grinder.statistics.registerSummaryExpression("User_defined_Error_Count", "(/ userLong1(+ (count timedTests)))")
grinder.statistics.registerSummaryExpression("User_defined_Long_Field", "(/ userLong2(+ (count timedTests)))")

test1 = new GTest(1, "Test1")
test2 = new GTest(2, "Test2")
test3 = new GTest(3, "Test3")
```

![image](https://user-images.githubusercontent.com/14273601/77378107-730f1600-6db8-11ea-8cf8-35a1bc728b88.png)
