### PR TITLE
Remove unnecessary vue hook

### DIFF
--- a/ngrinder-frontend/src/js/components/perftest/detail/Report.vue
+++ b/ngrinder-frontend/src/js/components/perftest/detail/Report.vue
@@ -136,10 +136,6 @@
         shownBsTab = false;
         logs = [];
 
-        created() {
-            this.fetchReportData();
-        }
-
         fetchReportData() {
             if (!this.id) {
                 return;


### PR DESCRIPTION
If old chart data exist in `{ngrinder-home}/perftest/{user}/{test-id}/report`
Intermittently,  `Report.vue` is rendered old chart.

because, it read old data in created hook before they are deleted.
so, remove problematic hook, chart data is [already handled by bootstrap tab event](https://github.com/naver/ngrinder/blob/develop/ngrinder-frontend/src/js/components/perftest/detail/Detail.vue#L307)