### PR TITLE
Beautify css

### DIFF
--- a/ngrinder-frontend/src/js/components/Base.vue
+++ b/ngrinder-frontend/src/js/components/Base.vue
@@ -202,7 +202,7 @@
             .popover-body {
                 max-height: 450px;
                 line-height: 20px;
-                overflow-y: scroll;
+                overflow-y: auto;
             }
         }
 

--- a/ngrinder-frontend/src/js/components/perftest/list/SmallChart.vue
+++ b/ngrinder-frontend/src/js/components/perftest/list/SmallChart.vue
@@ -201,13 +201,13 @@
         g.tick > text > tspan {
             font-size: 8px;
         }
+
+        tbody > tr:not([render="true"]) > td {
+            padding: 0;
+        }
     }
 
     .bb-tooltip {
         padding: 3px;
-    }
-
-    tbody > tr:not([render="true"]) > td {
-        padding: 0;
     }
 </style>


### PR DESCRIPTION
Adjust some css

1. Show popover scroll only when needed.
![image](https://user-images.githubusercontent.com/14273601/81246092-a6002700-9051-11ea-95a1-d609b4af85ea.png)

2. Prevent `SmallChart.vue`'s table style affect other components table style.

![image](https://user-images.githubusercontent.com/14273601/81246510-c54b8400-9052-11ea-8923-06249396d488.png)
