### PR TITLE
Support custom JVM classpath for test

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/PerfTestService.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/PerfTestService.java
@@ -501,14 +501,13 @@ public class PerfTestService extends AbstractPerfTestService implements Controll
 	}
 
 	/**
-	 * Build custom class path on the given {@link PerfTest}.
+	 * Build user library classpath on the given {@link PerfTest}.
 	 *
 	 * @param perfTest perftest
 	 * @return custom class path.
 	 */
-
 	@SuppressWarnings("ResultOfMethodCallIgnored")
-	public String getCustomClassPath(PerfTest perfTest) {
+	public String geUserLibraryClassPath(PerfTest perfTest) {
 		File perfTestDirectory = getDistributionPath(perfTest);
 		File libFolder = new File(perfTestDirectory, "lib");
 
@@ -596,7 +595,7 @@ public class PerfTestService extends AbstractPerfTestService implements Controll
 			}
 			grinderProperties.setInt(GRINDER_PROP_REPORT_TO_CONSOLE, 500);
 			grinderProperties.setProperty(GRINDER_PROP_USER, perfTest.getCreatedUser().getUserId());
-			grinderProperties.setProperty(GRINDER_PROP_JVM_CLASSPATH, getCustomClassPath(perfTest));
+			grinderProperties.setProperty(GRINDER_PROP_JVM_USER_LIBRARY_CLASSPATH, geUserLibraryClassPath(perfTest));
 			grinderProperties.setInt(GRINDER_PROP_IGNORE_SAMPLE_COUNT, getSafe(perfTest.getIgnoreSampleCount()));
 			grinderProperties.setBoolean(GRINDER_PROP_SECURITY, config.isSecurityEnabled());
 			grinderProperties.setProperty(GRINDER_PROP_SECURITY_LEVEL, config.getSecurityLevel());

--- a/ngrinder-controller/src/main/resources/ngrinder_agent_home_template/agent_agent.conf
+++ b/ngrinder-controller/src/main/resources/ngrinder_agent_home_template/agent_agent.conf
@@ -7,6 +7,8 @@ agent.region=${controllerRegion}
 
 # provide more agent java execution option if necessary.
 #agent.java_opt=
+# provide more agent jvm classpath if necessary.
+#agent.jvm.classpath=
 # set following false if you want to use more than 1G Xmx memory per a agent process.
 #agent.limit_xmx=true
 # please uncomment the following option if you want to send all logs to the controller.

--- a/ngrinder-core/src/main/java/net/grinder/engine/agent/LocalScriptTestDriveService.java
+++ b/ngrinder-core/src/main/java/net/grinder/engine/agent/LocalScriptTestDriveService.java
@@ -34,6 +34,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Properties;
 
+import static org.ngrinder.common.constants.GrinderConstants.GRINDER_PROP_JVM_CLASSPATH;
 import static org.ngrinder.common.util.EncodingUtils.decodePathWithUTF8;
 import static org.ngrinder.common.util.NoOp.noOp;
 
@@ -110,8 +111,8 @@ public class LocalScriptTestDriveService {
 			String grinderJVMClassPath = getHomeLibraryPath(classPathProcessor.buildForemostClasspathBasedOnCurrentClassLoader(LOGGER))
 				+ File.pathSeparator + getHomeLibraryPath(classPathProcessor.buildPatchClasspathBasedOnCurrentClassLoader(LOGGER))
 				+ File.pathSeparator + builder.buildCustomClassPath(true);
-			properties.setProperty("grinder.jvm.classpath", grinderJVMClassPath = grinderJVMClassPath.replace(";;", ";"));
-			LOGGER.info("grinder.jvm.classpath : {} ", grinderJVMClassPath);
+			properties.setProperty(GRINDER_PROP_JVM_CLASSPATH, grinderJVMClassPath = grinderJVMClassPath.replace(";;", ";"));
+			LOGGER.info(GRINDER_PROP_JVM_CLASSPATH + " : {} ", grinderJVMClassPath);
 			AgentIdentityImplementation agentIdentity = new AgentIdentityImplementation("validation");
 			agentIdentity.setNumber(0);
 			String newClassPath = classPathProcessor.buildClasspathBasedOnCurrentClassLoader(LOGGER);

--- a/ngrinder-core/src/main/java/net/grinder/engine/agent/PropertyBuilder.java
+++ b/ngrinder-core/src/main/java/net/grinder/engine/agent/PropertyBuilder.java
@@ -346,7 +346,7 @@ public class PropertyBuilder {
 	 * @param classPath class path
 	 * @return converted path.
 	 */
-	public String rebaseCustomClassPath(String classPath) {
+	public String rebaseUserLibraryClassPath(String classPath) {
 		StringBuilder newClassPath = new StringBuilder();
 		boolean isFirst = true;
 		for (String each : StringUtils.split(classPath, ";:")) {

--- a/ngrinder-core/src/main/java/org/ngrinder/common/constants/AgentConstants.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/common/constants/AgentConstants.java
@@ -26,6 +26,7 @@ public interface AgentConstants {
 	public static final String PROP_AGENT_CONTROLLER_PORT = "agent.controller_port";
 	public static final String PROP_AGENT_HOST_ID = "agent.host_id";
 	public static final String PROP_AGENT_JAVA_OPT = "agent.java_opt";
+	public static final String PROP_AGENT_JVM_CLASSPATH = "agent.jvm.classpath";
 	public static final String PROP_AGENT_LIMIT_XMX = "agent.limit_xmx";
 	public static final String PROP_AGENT_REGION = "agent.region";
 	public static final String PROP_AGENT_SERVER_MODE = "agent.server_mode";

--- a/ngrinder-core/src/main/java/org/ngrinder/common/constants/GrinderConstants.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/common/constants/GrinderConstants.java
@@ -32,6 +32,7 @@ public interface GrinderConstants {
 	public static final String GRINDER_PROP_SCRIPT = "grinder.script";
 	public static final String GRINDER_PROP_PARAM = "grinder.param";
 	public static final String GRINDER_PROP_JVM_CLASSPATH = "grinder.jvm.classpath";
+	public static final String GRINDER_PROP_JVM_USER_LIBRARY_CLASSPATH = "grinder.jvm.user.library.classpath";
 	public static final String GRINDER_PROP_JVM_ARGUMENTS = "grinder.jvm.arguments";
 	public static final String GRINDER_PROP_USE_CONSOLE = "grinder.useConsole";
 	public static final String GRINDER_PROP_REPORT_TO_CONSOLE = "grinder.reportToConsole.interval";

--- a/ngrinder-core/src/main/resources/agent-properties.map
+++ b/ngrinder-core/src/main/resources/agent-properties.map
@@ -7,6 +7,7 @@ agent.server_mode,,
 agent.all_logs,false,agent.send.all.logs
 agent.limit_xmx,true,agent.useXmxLimit
 agent.java_opt,,agent.javaopt
+agent.jvm.classpath,,
 agent.keep_logs,false,
 agent.update_always,false,
 agent.enable_local_dns,true,

--- a/ngrinder-core/src/main/resources/agent.conf
+++ b/ngrinder-core/src/main/resources/agent.conf
@@ -7,6 +7,8 @@ common.start_mode=agent
 
 # provide more agent java execution option if necessary.
 #agent.java_opt=
+# provide more agent jvm classpath if necessary.
+#agent.jvm.classpath=
 # set following false if you want to use more than 1G Xmx memory per a agent process.
 #agent.limit_xmx=true
 # please uncomment the following option if you want to send all logs to the controller.


### PR DESCRIPTION
Support custom JVM classpath for test.

1. Use `grinder.properties`

![image](https://user-images.githubusercontent.com/14273601/82286228-389cb080-99d8-11ea-9468-d06138974592.png)
> This feature not working in `security mode`

2. Use `agent.conf`

![image](https://user-images.githubusercontent.com/14273601/82286302-5d912380-99d8-11ea-8df3-755849d11919.png)
