### PR TITLE
Make chart duration show correctly

### DIFF
--- a/ngrinder-frontend/src/js/components/perftest/list/SmallChart.vue
+++ b/ngrinder-frontend/src/js/components/perftest/list/SmallChart.vue
@@ -95,16 +95,15 @@
                     onlyTotal: true,
                 },
             }).then(res => {
+                const interval = res.data['chartInterval'];
                 Object.entries(res.data).forEach(([key, value]) => {
                     res.data[key] = this.processData(value, key);
                 });
-                this.initCharts(res.data);
+                this.initCharts(res.data, interval);
             });
         }
-
-        initCharts(data) {
-            const interval = data['chartInterval'];
-
+        
+        initCharts(data, interval) {
             this.drawSmallChart(`tps_${this.rowData.id}`, 'TPS', data['TPS'].Total, interval);
             this.drawSmallChart(`mtt_${this.rowData.id}`, 'MTT', data['Mean_Test_Time_(ms)'].Total, interval);
             this.drawSmallChart(`mttfb_${this.rowData.id}`, 'MTTFB', data['Mean_time_to_first_byte'].Total, interval);

--- a/ngrinder-frontend/src/js/components/perftest/report/menu/PerfTest.vue
+++ b/ngrinder-frontend/src/js/components/perftest/report/menu/PerfTest.vue
@@ -82,6 +82,7 @@
                     imgWidth: parseInt(this.$refs.tpsChart.offsetWidth),
                 },
             }).then(res => {
+                const interval = res.data['chartInterval'];
                 const numOfTestRecord = Object.keys(res.data['TPS']).length;
 
                 Object.entries(res.data).forEach(([key, value]) => {
@@ -91,14 +92,13 @@
                     }
                     res.data[key] = this.processData(value, key, numOfTestRecord);
                 });
-                this.drawReportChart(res.data);
+                this.drawReportChart(res.data, interval);
 
             }).catch(() => this.showErrorMsg(this.i18n('common.message.loading.error')));
             $('[data-toggle="popover"]').popover();
         }
 
-        drawReportChart(data) {
-            const interval = data['chartInterval'];
+        drawReportChart(data, interval) {
             this.tpsChart = this.drawChart('tps-chart', data['TPS'], interval);
             this.meanTimeChart = this.drawChart('mean-time-chart', data['Mean_Test_Time_(ms)'], interval);
             this.meanTimeToFirstByteChart = this.drawChart('min-time-first-byte-chart', data['Mean_time_to_first_byte'], interval);


### PR DESCRIPTION
Make chart duration show correctly.

1. before

![image](https://user-images.githubusercontent.com/14273601/84500812-3d5f3680-acf0-11ea-9435-954bc22a2a62.png)

2. after

![image](https://user-images.githubusercontent.com/14273601/84500696-08eb7a80-acf0-11ea-8690-8ac3dcfb6b28.png)
