### PR TITLE
Remove agent configuration overwrite option

### DIFF
--- a/ngrinder-core/src/main/java/org/ngrinder/NGrinderAgentStarterParam.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/NGrinderAgentStarterParam.java
@@ -92,11 +92,6 @@ public class NGrinderAgentStarterParam {
 			}
 		};
 
-		@Parameter(names = {"-o", "--overwrite-config"}, required = false,
-				description = "overwrite overwrite the existing .ngrinder_agent/agent.conf with the local __agent.conf")
-		public Boolean overwriteConfig = null;
-
-
 		@Parameter(names = {"-ah", "--agent-home"}, required = false,
 				description = "this agent's unique home path. The default is ~/.ngrinder_agent")
 		public String agentHome = null;
@@ -139,10 +134,6 @@ public class NGrinderAgentStarterParam {
 		public void process() {
 			if (agentHome != null) {
 				System.setProperty("ngrinder.agent.home", agentHome);
-			}
-
-			if (overwriteConfig != null) {
-				System.setProperty(CommonConstants.PROP_OVERWRITE_CONFIG, "true");
 			}
 
 			if (silent != null) {

--- a/ngrinder-core/src/main/java/org/ngrinder/common/constants/CommonConstants.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/common/constants/CommonConstants.java
@@ -23,5 +23,4 @@ public interface CommonConstants {
 	public static final String PROP_COMMON_START_MODE = "common.start_mode";
 	public static final String PROP_COMMON_DEV_MODE = "common.dev_mode";
 	public static final String PROP_COMMON_SILENT_MODE = "common.silent_mode";
-	public static final String PROP_OVERWRITE_CONFIG = "common.overwrite_config";
 }

--- a/ngrinder-core/src/main/java/org/ngrinder/infra/AgentConfig.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/infra/AgentConfig.java
@@ -36,6 +36,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import static net.grinder.util.NetworkUtils.DEFAULT_LOCAL_HOST_ADDRESS;
+import static org.apache.commons.io.FileUtils.deleteQuietly;
 import static org.apache.commons.lang.StringUtils.trimToEmpty;
 import static org.ngrinder.common.util.ExceptionUtils.processException;
 import static org.ngrinder.common.util.NoOp.noOp;
@@ -82,25 +83,19 @@ public class AgentConfig implements AgentConstants, MonitorConstants, CommonCons
 		checkNotNull(home);
 		final File agentConfig = home.getFile("agent.conf");
 		File newAgentConfig = new File(getCurrentDirectory(), "__agent.conf");
-		if (agentConfig.exists()) {
-			if (System.getProperty(CommonConstants.PROP_OVERWRITE_CONFIG) != null) {
-				LOGGER.info("Overwrite the existing agent.conf with __agent.conf");
-			} else if (newAgentConfig.exists()) {
-				LOGGER.warn("The agent configuration file '{}' already exists.", agentConfig.getAbsolutePath());
-				LOGGER.warn("If you want to use the '{}' file", newAgentConfig.getAbsolutePath());
-				LOGGER.warn("Please run agent with -o option");
-				return;
-			}
-		}
+
 		if (newAgentConfig.exists()) {
+			LOGGER.info("Overwrite the existing agent.conf with __agent.conf");
 			home.copyFileTo(newAgentConfig, "agent.conf");
 			agentConfig.setLastModified(newAgentConfig.lastModified());
-		} else {
-			try {
-				home.writeFileTo(loadResource("/agent.conf"), "agent.conf");
-			} catch (IOException e) {
-				throw processException(e);
-			}
+			deleteQuietly(newAgentConfig);
+			return;
+		}
+
+		try {
+			home.writeFileTo(loadResource("/agent.conf"), "agent.conf");
+		} catch (IOException e) {
+			throw processException(e);
 		}
 	}
 
@@ -220,7 +215,7 @@ public class AgentConfig implements AgentConstants, MonitorConstants, CommonCons
 	public void removeAgentPidProperties() {
 		checkNotNull(home);
 		File file = home.getFile("pid");
-		FileUtils.deleteQuietly(file);
+		deleteQuietly(file);
 	}
 
 	/**


### PR DESCRIPTION
1. If `__agent.conf` exists, it is always overwritten & delete.
2. Remove `agent -o option`.