### PR TITLE
Change digest of cached files

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/PerfTestRunnable.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/PerfTestRunnable.java
@@ -27,7 +27,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.time.DateUtils;
 import org.ngrinder.agent.service.AgentService;
 import org.ngrinder.common.constant.ControllerConstants;
-import org.ngrinder.common.exception.NGrinderRuntimeException;
 import org.ngrinder.common.exception.PerfTestPrepareException;
 import org.ngrinder.extension.OnTestLifeCycleRunnable;
 import org.ngrinder.extension.OnTestSamplingRunnable;
@@ -236,13 +235,7 @@ public class PerfTestRunnable implements ControllerConstants {
 
 		distFiles
 			.stream()
-			.filter(file -> {
-				try {
-					return cachedDistFilesDigest.contains(getFileDigest(distDir, file));
-				} catch (IOException e) {
-					throw new NGrinderRuntimeException(e);
-				}
-			})
+			.filter(file -> cachedDistFilesDigest.contains(getFileDigest(distDir, file)))
 			.forEach(FileUtils::deleteQuietly);
 	}
 

--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/PerfTestService.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/PerfTestService.java
@@ -666,6 +666,7 @@ public class PerfTestService extends AbstractPerfTestService implements Controll
 
 		// Get all files in the script path.
 		ScriptHandler handler = scriptHandlerFactory.getHandler(scriptEntry);
+		LOGGER.info("Script type is '{}'.", handler.getKey());
 
 		ProcessingResultPrintStream processingResult = new ProcessingResultPrintStream(new ByteArrayOutputStream());
 		handler.prepareDist(perfTest.getId(), user, scriptEntry, perfTestDistDirectory, config.getControllerProperties(),

--- a/ngrinder-core/src/main/java/net/grinder/SingleConsole.java
+++ b/ngrinder-core/src/main/java/net/grinder/SingleConsole.java
@@ -96,7 +96,7 @@ public class SingleConsole extends AbstractSingleConsole implements Listener, Sa
 	private final Condition eventSyncCondition = new Condition();
 	private ProcessReports[] processReports;
 
-	// It contains cached distribution files md5 checksum from each agents.
+	// It contains cached distribution files digest from each agents.
 	private CopyOnWriteArrayList<Set<String>> agentCachedDistFilesDigestList = new CopyOnWriteArrayList<>();
 	private boolean cancel = false;
 
@@ -367,9 +367,9 @@ public class SingleConsole extends AbstractSingleConsole implements Listener, Sa
 	}
 
 	/**
-	 * Send Md5 checksum of unnecessary files to agents for refresh agent's distribution cache directory.
+	 * Send digest of unnecessary files to agents for refresh agent's distribution cache directory.
 	 *
-	 * @param distFilesDigest Required file's md5 checksum for currently running test.
+	 * @param distFilesDigest Required file's digest for currently running test.
 	 */
 	public void sendDistFilesDigestToAgents(Set<String> distFilesDigest) {
 		ForkJoinPool myPool = new ForkJoinPool(NUM_OF_SEND_FILE_DIGEST_THREAD);
@@ -379,7 +379,7 @@ public class SingleConsole extends AbstractSingleConsole implements Listener, Sa
 				.sendToAddressedAgents(
 					new AgentAddress(processReport.getAgentProcessReport().getAgentIdentity()),
 					new RefreshCacheMessage(distFilesDigest))));
-		LOGGER.info("Send md5 checksum of distribution files to agent for refresh agent's cache directory.");
+		LOGGER.info("Send digest of distribution files to agent for refresh agent's cache directory.");
 	}
 
 	/**
@@ -481,7 +481,7 @@ public class SingleConsole extends AbstractSingleConsole implements Listener, Sa
 	}
 
 	/**
-	 * Wait until the given size of agents are all connected and receive md5 checksum from there cached files.
+	 * Wait until the given size of agents are all connected and receive digest from there cached files.
 	 * It wait until 10 sec.
 	 *
 	 * @param size size of agent.

--- a/ngrinder-core/src/main/java/net/grinder/console/distribution/FileDistributionHandlerImplementation.java
+++ b/ngrinder-core/src/main/java/net/grinder/console/distribution/FileDistributionHandlerImplementation.java
@@ -34,7 +34,7 @@ import java.io.File;
  *
  * <p>Not thread safe.</p>
  *
- * @since 3.5.1
+ * @since 3.5.0
  */
 final class FileDistributionHandlerImplementation
 	implements FileDistributionHandler {

--- a/ngrinder-core/src/main/java/net/grinder/engine/agent/AgentImplementationEx.java
+++ b/ngrinder-core/src/main/java/net/grinder/engine/agent/AgentImplementationEx.java
@@ -540,8 +540,9 @@ public class AgentImplementationEx implements Agent, AgentConstants {
 					.getCacheHighWaterMark()));
 
 			File cacheDir = m_fileStore.getIncomingDirectory().getFile();
-			m_sender.send(new DistFilesDigestMessage(getAllFilesMd5ChecksumInDirectory(cacheDir)));
-			m_logger.info("Send md5 checksum of cached file to controller.");
+
+			m_sender.send(new DistFilesDigestMessage(getFilesDigest(cacheDir, getAllFilesInDirectory(cacheDir))));
+			m_logger.info("Send digest of cached files to controller.");
 
 			final MessageDispatchSender fileStoreMessageDispatcher = new MessageDispatchSender();
 			m_fileStore.registerMessageHandlers(fileStoreMessageDispatcher);

--- a/ngrinder-core/src/main/java/net/grinder/engine/agent/FileStore.java
+++ b/ngrinder-core/src/main/java/net/grinder/engine/agent/FileStore.java
@@ -31,6 +31,7 @@ import net.grinder.util.Directory;
 import net.grinder.util.FileContents;
 import net.grinder.util.StreamCopier;
 import org.apache.commons.io.FileUtils;
+import org.ngrinder.common.exception.NGrinderRuntimeException;
 import org.slf4j.Logger;
 
 import java.io.File;
@@ -39,15 +40,14 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
-import static net.grinder.util.FileUtils.getAllFilesInDirectory;
-import static net.grinder.util.FileUtils.getMd5;
+import static net.grinder.util.FileUtils.*;
 
 
 /**
  * FileStore for cache control in nGrinder.
  * This is the customized version of {@link FileStore} which grinder has.
  *
- * @since 3.5.1
+ * @since 3.5.0
  */
 final class FileStore {
 	private final Logger m_logger;
@@ -144,7 +144,13 @@ final class FileStore {
 						List<File> cachedFiles = getAllFilesInDirectory(cacheDir);
 						cachedFiles
 							.stream()
-							.filter(file -> !isRequiredFile(requiredFilesDigest, file))
+							.filter(file -> {
+								try {
+									return !requiredFilesDigest.contains(getFileDigest(cacheDir, file));
+								} catch (IOException e) {
+									throw new NGrinderRuntimeException(e);
+								}
+							})
 							.forEach(FileUtils::deleteQuietly);
 					} catch (IOException e) {
 						m_logger.info("Failed refresh cached file store", e);

--- a/ngrinder-core/src/main/java/net/grinder/engine/agent/FileStore.java
+++ b/ngrinder-core/src/main/java/net/grinder/engine/agent/FileStore.java
@@ -144,13 +144,7 @@ final class FileStore {
 						List<File> cachedFiles = getAllFilesInDirectory(cacheDir);
 						cachedFiles
 							.stream()
-							.filter(file -> {
-								try {
-									return !requiredFilesDigest.contains(getFileDigest(cacheDir, file));
-								} catch (IOException e) {
-									throw new NGrinderRuntimeException(e);
-								}
-							})
+							.filter(file ->  !requiredFilesDigest.contains(getFileDigest(cacheDir, file)))
 							.forEach(FileUtils::deleteQuietly);
 					} catch (IOException e) {
 						m_logger.info("Failed refresh cached file store", e);
@@ -210,14 +204,6 @@ final class FileStore {
 					m_cacheHighWaterMark = message.getCacheHighWaterMark();
 				}
 			});
-	}
-
-	private boolean isRequiredFile(Set<String> requiredFilesDigest, File file) {
-		try {
-			return requiredFilesDigest.contains(getMd5(file));
-		} catch (IOException e) {
-			return false;
-		}
 	}
 
 	private void createReadmeFile() throws CommunicationException {

--- a/ngrinder-core/src/main/java/net/grinder/engine/communication/DistFilesDigestMessage.java
+++ b/ngrinder-core/src/main/java/net/grinder/engine/communication/DistFilesDigestMessage.java
@@ -5,7 +5,7 @@ import net.grinder.communication.Message;
 import java.util.Set;
 
 /**
- * Message used to distribute a file's md5 checksum the console to the agent processes.
+ * Message used to distribute a file's digest.
  *
  * @since 3.5.0
  */

--- a/ngrinder-core/src/main/java/net/grinder/messages/agent/RefreshCacheMessage.java
+++ b/ngrinder-core/src/main/java/net/grinder/messages/agent/RefreshCacheMessage.java
@@ -7,7 +7,7 @@ import java.util.Set;
 /**
  * Message that refresh cache directory.
  *
- * @since 3.5.1
+ * @since 3.5.0
  * */
 public final class RefreshCacheMessage implements Message {
 	private Set<String> disFilesDigest;

--- a/ngrinder-core/src/main/java/net/grinder/util/FileUtils.java
+++ b/ngrinder-core/src/main/java/net/grinder/util/FileUtils.java
@@ -61,20 +61,18 @@ public class FileUtils {
 	 * @param file     Target file.
 	 *
 	 * */
-	public static String getFileDigest(File baseDir, File file) throws IOException {
-		return getSubPath(baseDir.getPath(), file.getPath()) + ":" + getMd5(file);
+	public static String getFileDigest(File baseDir, File file) {
+		try {
+			return getSubPath(baseDir.getPath(), file.getPath()) + ":" + getMd5(file);
+		} catch (IOException e) {
+			throw new NGrinderRuntimeException(e);
+		}
 	}
 
 	public static Set<String> getFilesDigest(File baseDir, List<File> files) {
 		return files
 			.stream()
-			.map(file -> {
-				try {
-					return getFileDigest(baseDir, file);
-				} catch (IOException e) {
-					throw new NGrinderRuntimeException(e);
-				}
-			})
+			.map(file -> getFileDigest(baseDir, file))
 			.collect(toSet());
 	}
 }

--- a/ngrinder-core/src/main/java/net/grinder/util/FileUtils.java
+++ b/ngrinder-core/src/main/java/net/grinder/util/FileUtils.java
@@ -1,5 +1,7 @@
 package net.grinder.util;
 
+import org.ngrinder.common.exception.NGrinderRuntimeException;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -14,12 +16,13 @@ import static java.nio.file.Paths.get;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.codec.digest.DigestUtils.md5Hex;
+import static org.ngrinder.common.util.PathUtils.getSubPath;
 import static org.ngrinder.common.util.StreamUtils.exceptionWrapper;
 
 /**
  * Convenient File utilities.
  *
- * @since 3.5.1
+ * @since 3.5.0
  */
 public class FileUtils {
 	/**
@@ -38,10 +41,6 @@ public class FileUtils {
 		return getAllFilesInDirectory(directory.getPath());
 	}
 
-	public static Set<String> getAllFilesMd5ChecksumInDirectory(File directory) throws IOException {
-		return getMd5(getAllFilesInDirectory(directory));
-	}
-
 	public static Set<String> getMd5(List<File> files) {
 		return files
 			.stream()
@@ -53,5 +52,29 @@ public class FileUtils {
 		try (FileInputStream fileInputStream = new FileInputStream(file)) {
 			return md5Hex(fileInputStream);
 		}
+	}
+
+	/**
+	 * Make file digest to {relative path from base directory}:{md5 checksum of file} format.
+	 *
+	 * @param baseDir  Base directory for calculate relative path.
+	 * @param file     Target file.
+	 *
+	 * */
+	public static String getFileDigest(File baseDir, File file) throws IOException {
+		return getSubPath(baseDir.getPath(), file.getPath()) + ":" + getMd5(file);
+	}
+
+	public static Set<String> getFilesDigest(File baseDir, List<File> files) {
+		return files
+			.stream()
+			.map(file -> {
+				try {
+					return getFileDigest(baseDir, file);
+				} catch (IOException e) {
+					throw new NGrinderRuntimeException(e);
+				}
+			})
+			.collect(toSet());
 	}
 }

--- a/ngrinder-core/src/main/java/org/ngrinder/common/util/PathUtils.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/common/util/PathUtils.java
@@ -81,4 +81,11 @@ public abstract class PathUtils {
 		}
 		return path;
 	}
+
+	public static String getSubPath(String basePath, String path) {
+		if (!path.contains(basePath)) {
+			return path;
+		}
+		return path.substring(path.lastIndexOf(basePath) + basePath.length());
+	}
 }

--- a/ngrinder-core/src/test/java/org/ngrinder/common/util/PathUtilsTest.java
+++ b/ngrinder-core/src/test/java/org/ngrinder/common/util/PathUtilsTest.java
@@ -3,6 +3,7 @@ package org.ngrinder.common.util;
 import org.junit.Test;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.ngrinder.common.util.PathUtils.getSubPath;
 
 
 public class PathUtilsTest {
@@ -16,5 +17,13 @@ public class PathUtilsTest {
 		assertThat(PathUtils.join("hello/world////", "//wow/")).isEqualTo("hello/world/wow");
 		assertThat(PathUtils.join("hello/world////", "//wow/")).isEqualTo("hello/world/wow");
 		assertThat(PathUtils.join("/hello/world////", "//wow////")).isEqualTo("hello/world/wow");
+	}
+
+	@Test
+	public void testGetSubPath() {
+		String basePath = "/Users/user/dev/intellij-workspace/ngrinder-develop/";
+		String path = "/Users/user/dev/intellij-workspace/ngrinder-develop/resources/resources.txt";
+
+		assertThat(getSubPath(basePath, path)).isEqualTo("resources/resources.txt");
 	}
 }


### PR DESCRIPTION
Currently, when determine if the file is cached or not, ngrinder only use md5 checksum.

Therefore, if you run test using same script after changing the path, ngrinder controller recognizes that as a cached file and doesn't send it to the agent.

To resolve that, I changed file's digest format to `{relative path from base directory}:{md5 checksum}`.
