### PR TITLE
Prevent overwriting of agent.conf when restarting agent

### DIFF
--- a/ngrinder-core/src/main/java/org/ngrinder/infra/AgentConfig.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/infra/AgentConfig.java
@@ -92,6 +92,10 @@ public class AgentConfig implements AgentConstants, MonitorConstants, CommonCons
 			return;
 		}
 
+		if (agentConfig.exists()) {
+			return;
+		}
+
 		try {
 			home.writeFileTo(loadResource("/agent.conf"), "agent.conf");
 		} catch (IOException e) {


### PR DESCRIPTION
Prevent overwriting of `agent.conf` when restarting agent.