### PR TITLE
Make script compared correctly

### DIFF
--- a/ngrinder-frontend/src/js/components/script/Editor.vue
+++ b/ngrinder-frontend/src/js/components/script/Editor.vue
@@ -247,7 +247,7 @@
         }
 
         contentChanged() {
-            return this.$refs.editor.getValue() !== this.file.content;
+            return !this.$utils.equalsIgnoreNewLineChar(this.$refs.editor.getValue(), this.file.content);
         }
 
         save(isClose) {

--- a/ngrinder-frontend/src/js/utils.js
+++ b/ngrinder-frontend/src/js/utils.js
@@ -12,6 +12,13 @@ class Utils {
     isNumeric(num){
         return !isNaN(num)
     }
+
+    equalsIgnoreNewLineChar(str1, str2) {
+        if (typeof str1 === 'string' && typeof str2 === 'string') {
+            return str1.replace(/\r\n/gm, '\n') === str2.replace(/\r\n/gm, '\n');
+        }
+        throw new TypeError('Arguments are not string');
+    }
 }
 
 export default new Utils();


### PR DESCRIPTION
When checking if the script is changed, new line character(`\n`, `\r\n`) should not affect the comparison result.