### PR TITLE
Prevent to flicker the script editor result console

### DIFF
--- a/ngrinder-frontend/src/js/components/script/Editor.vue
+++ b/ngrinder-frontend/src/js/components/script/Editor.vue
@@ -528,4 +528,8 @@
         width: 164px;
         height: 30px;
     }
+
+    .splitpanes .splitpanes__pane {
+        transition: none;   // Remove splitpanes initial transition
+    }
 </style>


### PR DESCRIPTION
The splitpanes divides panes evenly on `mounted` hook, then calculate given pane size.
Prevent to flicker editor result console by disable the splitpanes transition css.

Reference: https://github.com/antoniandre/splitpanes/issues/80