### PR TITLE
Prevent lazy initialize exception in spring security authentication object

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/spring/UserHandlerMethodArgumentResolver.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/spring/UserHandlerMethodArgumentResolver.java
@@ -50,7 +50,7 @@ public class UserHandlerMethodArgumentResolver implements HandlerMethodArgumentR
 
 	@Override
 	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
-			NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+			NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
 		User currentUser = getUserContext().getCurrentUser();
 
 		String userParam = webRequest.getParameter("ownerId");
@@ -71,11 +71,11 @@ public class UserHandlerMethodArgumentResolver implements HandlerMethodArgumentR
 		}
 		// Let this can be done with parameter as well.
 		switchUser = StringUtils.defaultIfBlank(webRequest.getParameter("switchUser"), switchUser);
-		
+
 		if (currentUser.getUserId().equals(switchUser)) {
 			currentUser.setOwnerUser(null);
 		} else if (StringUtils.isNotEmpty(switchUser)) {
-			User ownerUser = getUserService().getOne(switchUser);
+			User ownerUser = getUserService().getOneWithEagerFetch(switchUser);
 			// CurrentUser should remember whose status he used
 			if (currentUser.getRole().hasPermission(Permission.SWITCH_TO_ANYONE)
 					|| (ownerUser.getFollowers() != null && ownerUser.getFollowers().contains(currentUser))) {

--- a/ngrinder-controller/src/main/java/org/ngrinder/security/SecuredUser.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/security/SecuredUser.java
@@ -52,7 +52,7 @@ public class SecuredUser implements UserDetails {
 	 * @param userInfoProviderClass class name who provides the user info
 	 */
 	public SecuredUser(User user, String userInfoProviderClass) {
-		this.setUser(user);
+		this.user = user;
 		this.userInfoProviderClass = userInfoProviderClass;
 	}
 

--- a/ngrinder-controller/src/main/java/org/ngrinder/user/controller/UserApiController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/user/controller/UserApiController.java
@@ -66,7 +66,7 @@ public class UserApiController {
 	@GetMapping("/profile")
 	public Map<String, Object> getOne(User user) {
 		checkNotEmpty(user.getUserId(), "UserID should not be NULL!");
-		User one = userService.getOneWithFollowers(user.getUserId());
+		User one = userService.getOneWithEagerFetch(user.getUserId());
 
 		Map<String, Object> viewConfig = new HashMap<>();
 		viewConfig.put("allowPasswordChange", !config.isDemo());
@@ -117,7 +117,7 @@ public class UserApiController {
 	@GetMapping("/{userId}/detail")
 	@PreAuthorize("hasAnyRole('A')")
 	public Map<String, Object> getOneDetail(@PathVariable final String userId) {
-		User one = userService.getOneWithFollowers(userId);
+		User one = userService.getOneWithEagerFetch(userId);
 
 		Map<String, Object> viewConfig = new HashMap<>();
 		viewConfig.put("allowPasswordChange", true);

--- a/ngrinder-controller/src/main/java/org/ngrinder/user/service/UserService.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/user/service/UserService.java
@@ -95,24 +95,23 @@ public class UserService extends AbstractUserService {
 	@Cacheable(value = DIST_CACHE_USERS, key = "#userId")
 	@Override
 	public User getOne(String userId) {
-		User user  = userRepository.findOneByUserId(userId);
-		if (user != null) {
-			initialize(user.getFollowers());
-		}
-		return user;
+		return userRepository.findOneByUserId(userId);
 	}
 
 	/**
-	 * Get user by user id with followers.
+	 * Get user by user id with eager fetch.
 	 *
 	 * @param userId user id
 	 * @return user
 	 */
 	@Transactional
-	public User getOneWithFollowers(String userId) {
-		User one = userRepository.findOneByUserId(userId);
-		one.getFollowers().size();
-		return one;
+	public User getOneWithEagerFetch(String userId) {
+		User user = userRepository.findOneByUserId(userId);
+		if (user != null) {
+			initialize(user.getOwners());
+			initialize(user.getFollowers());
+		}
+		return user;
 	}
 
 	/**

--- a/ngrinder-core/src/main/java/org/ngrinder/model/User.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/model/User.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import org.apache.commons.lang.StringUtils;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Type;
 


### PR DESCRIPTION
Currently, we are using the `SecuredUser` object as a spring security's authentication principal.
It is used in some of our codes.

case of below, It emits `lazy initialize exception(no session)`.
because the `User` object stored in `SecuredUser` at login time is not properly initialized the fields that require lazy fetch.

so, I changed a `SecuredUser` to have eager fetched user object at login time.

```
SecuredUser secureUser = cast(authentication.getPrincipal());
User user = secureUser.getUser();

...

// Emit lazy initialize exception (no session)
List<User> owners = user.getOwners();
```

[Code snippet link](https://github.com/naver/ngrinder/blob/develop/ngrinder-controller/src/main/java/org/ngrinder/security/UserSwitchPermissionVoter.java#L56)