### PR TITLE
Make the H2 console optionally available

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/config/SecurityConfig.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/config/SecurityConfig.java
@@ -171,7 +171,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 			.key("ngrinder")
 			.userDetailsService(ngrinderUserDetailsService)
 			.and()
-			.csrf().disable().exceptionHandling().authenticationEntryPoint(delegatingAuthenticationEntryPoint());
+			.csrf().disable().exceptionHandling().authenticationEntryPoint(delegatingAuthenticationEntryPoint())
+			.and()
+			.headers().frameOptions().sameOrigin();
 	}
 
 	/**

--- a/ngrinder-controller/src/main/resources/application.yml
+++ b/ngrinder-controller/src/main/resources/application.yml
@@ -33,3 +33,7 @@ spring:
     multipart:
       max-file-size: 100MB
       max-request-size: 100MB
+  h2:
+    console:
+      enabled: false
+      path: /h2-console


### PR DESCRIPTION
When using H2 for the database of ngrinder, You can just pass `--spring.h2.console.enabled=true` as a environment variables to enable H2 console.

You can access via `{ip}:{port}/h2-console`

<img src="https://user-images.githubusercontent.com/14273601/96323176-f34be000-1056-11eb-9280-df684dac08e9.png" width="370" height="320" /> <img src="https://user-images.githubusercontent.com/14273601/96323394-e11e7180-1057-11eb-8710-bbe46a88c8b2.png" width="580" height="370" />


