### PR TITLE
Escape response body in result console

### DIFF
--- a/ngrinder-frontend/src/js/components/script/Editor.vue
+++ b/ngrinder-frontend/src/js/components/script/Editor.vue
@@ -362,7 +362,7 @@
                 },
                 hostString: this.targetHosts.join(','),
             }).then(res => {
-                this.showScriptValidationResult(this.appendEditorLink(res.data));
+                this.showScriptValidationResult(this.appendEditorLink(this.$htmlEntities.encode(res.data)));
                 this.validated = true;
             }).catch(() => this.showErrorMsg(this.i18n('script.editor.validate.error')))
               .finally(this.hideProgressBar);


### PR DESCRIPTION
If the response body has HTML contents It rendered in the result console.
so the response body is escaped to prevent it.