### PR TITLE
Fix unstoppable abnormal test

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/PerfTestRunnable.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/PerfTestRunnable.java
@@ -398,10 +398,14 @@ public class PerfTestRunnable implements ControllerConstants {
 		singleConsole.addListener(new ConsoleShutdownListener() {
 			@Override
 			public void readyToStop(StopReason stopReason) {
-				perfTestService.markAbnormalTermination(perfTest, stopReason);
-				LOG.error("Abnormal test {} due to {}", perfTest.getId(), stopReason.name());
+				PerfTest fetchedPerftest = perfTestService.getOne(perfTest.getId());
+				if (fetchedPerftest.getStatus().isStoppable()) {
+					perfTestService.markAbnormalTermination(perfTest, stopReason);
+					LOG.error("Abnormal test {} due to {}", perfTest.getId(), stopReason.name());
+				}
 			}
 		});
+
 		long startTime = singleConsole.startTest(grinderProperties);
 		perfTest.setStartTime(ofEpochMilli(startTime));
 		addSamplingListeners(perfTest, singleConsole);

--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/PerfTestService.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/PerfTestService.java
@@ -89,8 +89,7 @@ import static org.ngrinder.common.util.NoOp.noOp;
 import static org.ngrinder.common.util.Preconditions.checkNotEmpty;
 import static org.ngrinder.common.util.Preconditions.checkNotNull;
 import static org.ngrinder.common.util.TypeConvertUtils.cast;
-import static org.ngrinder.model.Status.PREPARE_DISTRIBUTION;
-import static org.ngrinder.model.Status.getProcessingOrTestingTestStatus;
+import static org.ngrinder.model.Status.*;
 import static org.ngrinder.perftest.repository.PerfTestSpecification.*;
 
 /**
@@ -1033,7 +1032,6 @@ public class PerfTestService extends AbstractPerfTestService implements Controll
 		// This will be not be effective on cluster mode.
 		consoleManager.getConsoleUsingPort(perfTest.getPort()).cancel();
 		perfTest.setStopRequest(true);
-		perfTestRepository.save(perfTest);
 	}
 
 	/**

--- a/ngrinder-core/src/main/java/net/grinder/StopReason.java
+++ b/ngrinder-core/src/main/java/net/grinder/StopReason.java
@@ -26,7 +26,7 @@ public enum StopReason {
 	TOO_MANY_ERRORS("Too many errors"),
 	/** Error while test preparation. */
 	ERROR_WHILE_PREPARE("Test preparation error"),
-	/** Error while first execution. */
+	/** Error while first execution or no recording. */
 	SCRIPT_ERROR("Script error"),
 	/** Error by too much overall traffic on the given region. */
 	TOO_MUCH_TRAFFIC_ON_REGION("Too much traffic error"),

--- a/ngrinder-core/src/main/java/org/ngrinder/model/Status.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/model/Status.java
@@ -90,7 +90,7 @@ public enum Status {
 	/**
 	 * Detected Abnormal testing.
 	 */
-	ABNORMAL_TESTING(StatusCategory.TESTING),
+	ABNORMAL_TESTING(StatusCategory.ABNORMAL_TESTING),
 	/**
 	 * Test finished.
 	 */
@@ -198,10 +198,12 @@ public enum Status {
 	 * Check this status is the working status.
 	 *
 	 * @param status status
-	 * @return true if it's in {@link StatusCategory}'s PROCESSING or TESTING.
+	 * @return true if it's in {@link StatusCategory}'s PROCESSING or TESTING or ABNORMAL_TESTING.
 	 */
 	private static boolean isWorkingStatus(Status status) {
-		return status.getCategory() == StatusCategory.PROGRESSING || status.getCategory() == StatusCategory.TESTING;
+		return status.getCategory() == StatusCategory.PROGRESSING ||
+			status.getCategory() == StatusCategory.TESTING ||
+			status.getCategory() == StatusCategory.ABNORMAL_TESTING;
 	}
 
 	/**

--- a/ngrinder-core/src/main/java/org/ngrinder/model/StatusCategory.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/model/StatusCategory.java
@@ -33,6 +33,10 @@ public enum StatusCategory {
 	 */
 	TESTING("green_anime.gif", true, false, false),
 	/**
+	 * Abnormal testing.
+	 */
+	ABNORMAL_TESTING("yellow_anime.gif", false, false, false),
+	/**
 	 * Finished normally.
 	 */
 	FINISHED("green.png", false, true, true),


### PR DESCRIPTION
If user doesn't properly set a test recording(no recording) in the script. After the test is terminated, the test remains as abnormal testing state and can't stop(It can only delete). So, before updating as abnormal testing status, check if the test is stoppable.

1. Fix unstoppable abnormal test.
2. Add abnormal testing status category.