### PR TITLE
Add bintray gradle configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+  id "com.jfrog.bintray" version "1.8.5"
+}
+
 allprojects  {
   apply plugin: "idea"
 
@@ -21,6 +25,7 @@ allprojects  {
 subprojects {
   apply plugin: "java"
   apply plugin: "maven-publish"
+  apply plugin: "com.jfrog.bintray"
 
   compileJava.options.encoding = "UTF-8"
   compileTestJava.options.encoding = "UTF-8"
@@ -68,11 +73,58 @@ subprojects {
         from components.java
         artifact sourceJar
         artifact javadocJar
+        pom {
+          name = "org.ngrinder:${project.name}"
+          description = "${project.name} module"
+          url = "https://github.com/naver/ngrinder"
+          licenses {
+            license {
+              name = "The Apache License, Version 2.0"
+              url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+          }
+//          Below field is required to publish to the Maven central. Please modify before publishing.
+//          developers {
+//            developer {
+//              id = "{please_input_your_id}"
+//              name = "{please_input_your_name}"
+//              email = "{please_input_your_email}"
+//            }
+//          }
+          scm {
+            connection = "scm:git:git://github.com/naver/ngrinder.git"
+            developerConnection = "scm:git:ssh://github.com/naver/ngrinder.git"
+            url = "https://github.com/naver/ngrinder"
+          }
+        }
       }
     }
-    repositories {
-      maven {
-        url = "file:../../ngrinder.maven.repo/releases/"
+  }
+
+  bintray {
+    user =  project.bintrayUser
+    key =  project.bintrayKey
+    publications = ["nGrinerModules"]
+    publish = true
+    override = true
+
+    pkg {
+      repo = "ngrinder"
+      name = project.name
+      userOrg = "navercorp"
+      licenses = ["Apache-2.0"]
+      websiteUrl = "https://github.com/naver/ngrinder"
+      issueTrackerUrl = "https://github.com/naver/ngrinder/issues"
+      vcsUrl = "https://github.com/naver/ngrinder.git"
+      labels = ["ngrinder"]
+      publicDownloadNumbers = true
+      version {
+        name = project.version
+        released = new Date()
+        gpg {
+          sign = true
+          passphrase = project.bintrayGpgPassphrase
+        }
       }
     }
   }


### PR DESCRIPTION
Add bintray gradle configuration to publish submodules.

It can be used like `./gradlew :ngrinder-groovy:bintrayUpload -PbintrayUser={bintray_user_id} -PbintrayKey={bintray_user_api_key} -PbintrayGpgPassphrase={bintray_user_gpg_private_key_passphrase}`