### PR TITLE
Fix java serialization conflict during agent update

### DIFF
--- a/ngrinder-core/src/main/java/net/grinder/engine/communication/AgentUpdateGrinderMessage.java
+++ b/ngrinder-core/src/main/java/net/grinder/engine/communication/AgentUpdateGrinderMessage.java
@@ -30,7 +30,7 @@ public class AgentUpdateGrinderMessage implements Message {
 	/**
 	 * -1 is ending, -2 is error
 	 */
-	private final int next;
+	private int next;
 	private final long checksum;
 
 	/**


### PR DESCRIPTION
After clean up all of the codes, the agent update message mistakenly became not-compatible b/w current controller and old agent. It's because the generated serialVersionUIDs were different from previous version. so I roll back the `AgentUpdateGrinderMessage` to make compatibility of old version agents.