### PR TITLE
Cancel progressing state test when starting controller

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/config/TaskConfig.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/config/TaskConfig.java
@@ -35,6 +35,7 @@ public class TaskConfig implements SchedulingConfigurer, AsyncConfigurer {
 		taskScheduler.initialize();
 		return taskScheduler;
 	}
+
 	@Override
 	public Executor getAsyncExecutor() {
 		ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();

--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/PerfTestService.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/PerfTestService.java
@@ -458,7 +458,12 @@ public class PerfTestService extends AbstractPerfTestService implements Controll
 
 	@Override
 	public List<PerfTest> getAllTesting() {
-		return getAll(null, config.getRegion(), Status.getTestingTestStates());
+		return getAll(null, config.getRegion(), Status.getTestStatesByCategory(StatusCategory.TESTING));
+	}
+
+	@Override
+	public List<PerfTest> getAllProgressing() {
+		return getAll(null, config.getRegion(), Status.getTestStatesByCategory(StatusCategory.PROGRESSING));
 	}
 
 	public List<PerfTest> getAllAbnormalTesting() {

--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/samplinglistener/PerfTestSamplingCollectorListener.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/samplinglistener/PerfTestSamplingCollectorListener.java
@@ -42,7 +42,7 @@ public class PerfTestSamplingCollectorListener implements SamplingLifeCycleListe
 	                                         final PerfTestService perfTestService,
 	                                         ScheduledTaskService scheduledTaskService) {
 		this.scheduledTaskService = scheduledTaskService;
-		// Make it separate asyc call to remove the delay on the sampling.
+		// Make it separate async call to remove the delay on the sampling.
 		this.runnable = () -> perfTestService.saveStatistics(singleConsole, perfTestId);
 	}
 

--- a/ngrinder-core/src/main/java/net/grinder/StopReason.java
+++ b/ngrinder-core/src/main/java/net/grinder/StopReason.java
@@ -33,7 +33,9 @@ public enum StopReason {
 	/** Normal Stop. */
 	NORMAL("Normal stop"),
 	/** Cancel By User. */
-	CANCEL_BY_USER("Cancel by user");
+	CANCEL_BY_USER("Cancel by user"),
+	/** Cancel By System. */
+	CANCEL_BY_SYSTEM("Cancel by system");
 
 	private final String display;
 

--- a/ngrinder-core/src/main/java/org/ngrinder/model/Status.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/model/Status.java
@@ -211,10 +211,10 @@ public enum Status {
 	 *
 	 * @return status list
 	 */
-	public static Status[] getTestingTestStates() {
+	public static Status[] getTestStatesByCategory(StatusCategory statusCategory) {
 		List<Status> status = new ArrayList<>();
 		for (Status each : values()) {
-			if (each.getCategory() == StatusCategory.TESTING) {
+			if (each.getCategory().equals(statusCategory)) {
 				status.add(each);
 			}
 		}

--- a/ngrinder-core/src/main/java/org/ngrinder/service/IPerfTestService.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/service/IPerfTestService.java
@@ -118,6 +118,13 @@ public interface IPerfTestService {
 	List<PerfTest> getAllTesting();
 
 	/**
+	 * Get currently progressing PerfTest.
+	 *
+	 * @return found {@link PerfTest} list
+	 */
+	List<PerfTest> getAllProgressing();
+
+	/**
 	 * Get PerfTest Directory in which the distributed file is stored.
 	 *
 	 * @param perfTest	pefTest from which distribution directory calculated


### PR DESCRIPTION
If there is a progressing state test(blue anime ball) when starting the controller. It becomes a zombie test.(delete only)
So, clean up all tests when starting the controller.