### PR TITLE
Fix validation error when using AppClassLoader in over JDK9

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/agent/controller/MonitorDownloadController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/agent/controller/MonitorDownloadController.java
@@ -25,7 +25,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.File;
-import java.net.URLClassLoader;
 
 import lombok.RequiredArgsConstructor;
 
@@ -67,8 +66,8 @@ public class MonitorDownloadController {
 	@GetMapping("")
 	public String download(ModelMap model) {
 		try {
-			final File monitorPackage = agentPackageService.createPackage(monitorPackageHandler, (URLClassLoader) getClass().getClassLoader(),
-				"", null, config.getMonitorPort(), "");
+			final File monitorPackage = agentPackageService.createPackage(monitorPackageHandler, "",
+				null, config.getMonitorPort(), "");
 			model.clear();
 			return "redirect:/monitor/download/" + monitorPackage.getName();
 		} catch (Exception e) {

--- a/ngrinder-controller/src/main/java/org/ngrinder/packages/AgentPackageHandler.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/packages/AgentPackageHandler.java
@@ -6,7 +6,6 @@ import org.ngrinder.infra.schedule.ScheduledTaskService;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
-import java.net.URLClassLoader;
 import java.util.Map;
 import java.util.Set;
 
@@ -74,8 +73,8 @@ public class AgentPackageHandler extends PackageHandler {
 	}
 
 	@Override
-	public Set<String> getPackageDependentLibs(URLClassLoader urlClassLoader) {
-		Set<String> libs = getDependentLibs(urlClassLoader);
+	public Set<String> getPackageDependentLibs() {
+		Set<String> libs = getDependentLibs();
 		libs.add("ngrinder-core");
 		libs.add("ngrinder-runtime");
 		libs.add("ngrinder-groovy");

--- a/ngrinder-controller/src/main/java/org/ngrinder/packages/MonitorPackageHandler.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/packages/MonitorPackageHandler.java
@@ -2,7 +2,6 @@ package org.ngrinder.packages;
 
 import org.springframework.stereotype.Component;
 
-import java.net.URLClassLoader;
 import java.util.Map;
 import java.util.Set;
 
@@ -17,8 +16,8 @@ public class MonitorPackageHandler extends PackageHandler {
 	}
 
 	@Override
-	public Set<String> getPackageDependentLibs(URLClassLoader urlClassLoader) {
-		return super.getDependentLibs(urlClassLoader);
+	public Set<String> getPackageDependentLibs() {
+		return getDependentLibs();
 	}
 
 	@Override

--- a/ngrinder-core/src/main/java/net/grinder/engine/agent/LocalScriptTestDriveService.java
+++ b/ngrinder-core/src/main/java/net/grinder/engine/agent/LocalScriptTestDriveService.java
@@ -31,9 +31,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.Properties;
 
+import static net.grinder.util.AbstractGrinderClassPathProcessor.getClassPaths;
 import static org.ngrinder.common.constants.GrinderConstants.GRINDER_PROP_JVM_CLASSPATH;
 import static org.ngrinder.common.util.EncodingUtils.decodePathWithUTF8;
 import static org.ngrinder.common.util.NoOp.noOp;
@@ -232,12 +232,12 @@ public class LocalScriptTestDriveService {
 	}
 
 	private boolean isRunningOnWas() {
-		return ((URLClassLoader) LocalScriptTestDriveService.class.getClassLoader()).getURLs()[0].getProtocol().equals("jar");
+		return getClassPaths(LocalScriptTestDriveService.class.getClassLoader())[0].getProtocol().equals("jar");
 	}
 
 	private String runtimeClassPath() {
 		StringBuilder runtimeClassPath = new StringBuilder();
-		for (URL url : ((URLClassLoader) LocalScriptTestDriveService.class.getClassLoader()).getURLs()) {
+		for (URL url : getClassPaths(LocalScriptTestDriveService.class.getClassLoader())) {
 			if (url.getPath().contains("ngrinder-runtime") || url.getPath().contains("ngrinder-groovy")) {
 				runtimeClassPath.append(decodePathWithUTF8(url.getFile())).append(File.pathSeparator);
 			}

--- a/ngrinder-core/src/main/java/org/ngrinder/common/util/TypeConvertUtils.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/common/util/TypeConvertUtils.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ngrinder.common.util;
+
+public abstract class TypeConvertUtils {
+
+	/**
+	 * Convert the given object to the inferred return type.
+	 *
+	 * @param object object to be converted.
+	 * @param <T>    converted type
+	 * @return converted object.
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> T cast(Object object) {
+		return (T) object;
+	}
+}

--- a/ngrinder-core/src/main/java/org/ngrinder/model/PerfTest.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/model/PerfTest.java
@@ -30,12 +30,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.SortedSet;
 
-import static com.sun.jmx.mbeanserver.Util.cast;
 import static java.util.Date.from;
 import static org.apache.commons.lang.ObjectUtils.defaultIfNull;
 import static org.ngrinder.common.util.AccessUtils.getSafe;
 import static org.ngrinder.common.util.DateUtils.dateToString;
 import static org.ngrinder.common.util.DateUtils.ms2Time;
+import static org.ngrinder.common.util.TypeConvertUtils.cast;
 
 /**
  * Performance Test Entity.


### PR DESCRIPTION
From JDK9 the application class loader is no longer an instance of `java.net.URLClassLoader`
Therefore in a certain environment(run on Intellij), It emits `ClassCastException` when validating script. 
