### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a bug & errors report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### 1. Describe the bug 🐞 
+A clear and concise description of what the bug is.
+
+### 2. Reproduction steps
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+### 3. Environment
+- Controller
+     - OS:
+     - Browser:
+     - JDK version:
+     - Controller version:
+- Agent
+     - OS:
+     - JDK version:
+     - Agent version:
+
+### 4. Screenshots
+If necessary, add screenshots to help explain your problem.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: nGrinder community forum
+    url: https://github.com/naver/ngrinder/discussions
+    about: Please ask and answer questions here.


### PR DESCRIPTION
Provide issue template.

1. In issues tab

If click the nGrinder community forum `open` button, It is linked to our discussions tab.

![image](https://user-images.githubusercontent.com/14273601/103033103-0a520580-45a5-11eb-838b-870cfb067459.png)

2. Template format

![image](https://user-images.githubusercontent.com/14273601/103071661-6b122a00-4607-11eb-8013-d847fc456e5f.png)


