### PR TITLE
Bump up Jython

### DIFF
--- a/ngrinder-controller/build.gradle
+++ b/ngrinder-controller/build.gradle
@@ -44,7 +44,6 @@ dependencies {
         exclude (module: "platform")
     }
     compile (group: "javax.servlet.jsp", name: "jsp-api", version: "2.1")
-    compile (group: "org.python", name: "jython-standalone", version: "2.5.3")
     compile (group: "com.google.guava", name: "guava", version: "20.0")
     compile (group: "org.springframework.security", name: "spring-security-taglibs", version: spring_security_version)
     compile (group: "org.liquibase", name: "liquibase-core", version: "3.5.3")

--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/ConsoleManager.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/ConsoleManager.java
@@ -77,7 +77,7 @@ public class ConsoleManager {
 				consoleEntry.occupySocket();
 				consoleQueue.add(consoleEntry);
 			} catch (Exception ex) {
-				LOG.error("socket binding to {}:{} is failed", currentIP, port);
+				LOG.error("Socket binding to {}:{} is failed ({})", currentIP, port, ex.getMessage());
 			}
 		}
 

--- a/ngrinder-controller/src/main/java/org/ngrinder/script/handler/ScriptHandler.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/script/handler/ScriptHandler.java
@@ -260,9 +260,9 @@ public abstract class ScriptHandler implements ControllerConstants {
 		}
 
 		for (FileEntry eachFileEntry : libFileEntries) {
-			// Skip jython 2.5... it's already included.
-			if (startsWithIgnoreCase(eachFileEntry.getFileName(), "jython-2.5.")
-					|| startsWithIgnoreCase(eachFileEntry.getFileName(), "jython-standalone-2.5.")) {
+			// Skip jython 2.7... it's already included.
+			if (startsWithIgnoreCase(eachFileEntry.getFileName(), "jython-2.7.")
+					|| startsWithIgnoreCase(eachFileEntry.getFileName(), "jython-standalone-2.7.")) {
 				continue;
 			}
 			FileType fileType = eachFileEntry.getFileType();

--- a/ngrinder-core/build.gradle
+++ b/ngrinder-core/build.gradle
@@ -8,7 +8,6 @@ dependencies {
     compile (group: "org.pf4j", name: "pf4j", version:"3.0.1")
     compile (group: "javax.servlet", name: "javax.servlet-api", version:"3.1.0")
     compile (group: "commons-collections", name: "commons-collections", version:"3.2.1")
-    compile (group: "org.python", name: "jython-standalone", version:"2.5.3")
     compile (group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: jackson_version)
     compile (group: "com.fasterxml.jackson.core", name: "jackson-databind", version: jackson_version)
     compile (group: "net.java.dev.jna", name: "jna", version:"5.6.0")

--- a/ngrinder-core/src/main/java/net/grinder/lang/jython/JythonGrinderClassPathProcessor.java
+++ b/ngrinder-core/src/main/java/net/grinder/lang/jython/JythonGrinderClassPathProcessor.java
@@ -35,8 +35,8 @@ public class JythonGrinderClassPathProcessor extends AbstractGrinderClassPathPro
 	@Override
 	protected void initMore() {
 		List<String> usefulJarList = getUsefulJarList();
-		usefulJarList.add("jython-2.5");
-		usefulJarList.add("jython-standalone-2.5");
+		usefulJarList.add("jython-2.7");
+		usefulJarList.add("jython-standalone-2.7");
 		usefulJarList.add("commons-io");
 		usefulJarList.add("commons-lang");
 	}

--- a/ngrinder-runtime/build.gradle
+++ b/ngrinder-runtime/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     compile (group: "org.hamcrest", name: "hamcrest-all", version:"1.1")
     compile (group: "junit", name: "junit", version: junit_version)
     compile (group: "asm", name: "asm", version:"3.3.1")
+    compile (group: "org.python", name: "jython-standalone", version:"2.7.2")
     compile (group: "net.sf.grinder", name: "grinder", version:"3.9.1") {
         exclude (module: "clojure")
         exclude (module: "jython")

--- a/ngrinder-runtime/src/main/java/net/grinder/engine/process/GrinderProcess.java
+++ b/ngrinder-runtime/src/main/java/net/grinder/engine/process/GrinderProcess.java
@@ -81,7 +81,7 @@ import static java.lang.System.getProperty;
  *
  * @author Paco Gomez
  * @author Philip Aston
- * @author JunHo Yoon (modifed for nGrinder)
+ * @author JunHo Yoon (modified for nGrinder)
  * @see GrinderThread
  */
 final class GrinderProcess {

--- a/ngrinder-runtime/src/main/java/net/grinder/scriptengine/jython/JythonScriptEngineService.java
+++ b/ngrinder-runtime/src/main/java/net/grinder/scriptengine/jython/JythonScriptEngineService.java
@@ -11,6 +11,7 @@ import net.grinder.scriptengine.Instrumenter;
 import net.grinder.scriptengine.ScriptEngineService;
 import net.grinder.scriptengine.jython.instrumentation.dcr.Jython22Instrumenter;
 import net.grinder.scriptengine.jython.instrumentation.dcr.Jython25Instrumenter;
+import net.grinder.scriptengine.jython.instrumentation.dcr.Jython27Instrumenter;
 import net.grinder.scriptengine.jython.instrumentation.traditional.TraditionalJythonInstrumenter;
 import net.grinder.util.FileExtensionMatcher;
 import net.grinder.util.weave.WeavingException;
@@ -81,10 +82,15 @@ public final class JythonScriptEngineService implements ScriptEngineService {
 			if (m_dcrContext != null) {
 				if (instrumenters.size() == 0) {
 					try {
-						instrumenters.add(new Jython25Instrumenter(m_dcrContext));
+						instrumenters.add(new Jython27Instrumenter(m_dcrContext));
 					} catch (WeavingException e) {
-						// Jython 2.5 not available, try Jython 2.1/2.2.
-						instrumenters.add(new Jython22Instrumenter(m_dcrContext));
+						try {
+							// Jython 2.7 not available, try Jython 2.5
+							instrumenters.add(new Jython25Instrumenter(m_dcrContext));
+						} catch (WeavingException ex) {
+							// Jython 2.5 not available, try Jython 2.1/2.2.
+							instrumenters.add(new Jython22Instrumenter(m_dcrContext));
+						}
 					}
 				}
 			}

--- a/ngrinder-runtime/src/main/java/net/grinder/scriptengine/jython/instrumentation/dcr/AbstractJythonDCRInstrumenter.java
+++ b/ngrinder-runtime/src/main/java/net/grinder/scriptengine/jython/instrumentation/dcr/AbstractJythonDCRInstrumenter.java
@@ -46,7 +46,7 @@ import org.python.core.PyReflectedFunction;
 
 
 /**
- * Common code used by the Jython DCR instrumenters.
+ * Common code used by the Jython DCR instrumenters. (modified for nGrinder)
  *
  * @author Philip Aston
  */
@@ -124,7 +124,7 @@ abstract class AbstractJythonDCRInstrumenter extends AbstractDCRInstrumenter {
 				// PyMethod is used for bound and unbound Python methods, and
 				// bound Java methods.
 
-				if (pyMethod.im_func instanceof PyReflectedFunction) {
+				if (pyMethod.__func__ instanceof PyReflectedFunction) {
 
 					// Its Java.
 
@@ -134,8 +134,8 @@ abstract class AbstractJythonDCRInstrumenter extends AbstractDCRInstrumenter {
 					// Here, we defensively cope with unbound methods, but not
 					// constructors.
 					transform(recorder,
-						(PyReflectedFunction)pyMethod.im_func,
-						pyMethod.im_self.__tojava__(Object.class));
+						(PyReflectedFunction)pyMethod.__func__,
+						pyMethod.__self__.__tojava__(Object.class));
 				}
 				else {
 					transform(recorder, pyMethod);

--- a/ngrinder-runtime/src/main/java/net/grinder/scriptengine/jython/instrumentation/dcr/AbstractJythonDCRInstrumenter.java
+++ b/ngrinder-runtime/src/main/java/net/grinder/scriptengine/jython/instrumentation/dcr/AbstractJythonDCRInstrumenter.java
@@ -1,0 +1,294 @@
+// Copyright (C) 2011 Philip Aston
+// All rights reserved.
+//
+// This file is part of The Grinder software distribution. Refer to
+// the file LICENSE which is part of The Grinder distribution for
+// licensing details. The Grinder distribution is available on the
+// Internet at http://grinder.sourceforge.net/
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+// OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package net.grinder.scriptengine.jython.instrumentation.dcr;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import net.grinder.script.NonInstrumentableTypeException;
+import net.grinder.script.Test.InstrumentationFilter;
+import net.grinder.scriptengine.AbstractDCRInstrumenter;
+import net.grinder.scriptengine.DCRContext;
+import net.grinder.scriptengine.Recorder;
+import net.grinder.util.weave.Weaver.TargetSource;
+
+import org.python.core.PyClass;
+import org.python.core.PyFunction;
+import org.python.core.PyInstance;
+import org.python.core.PyMethod;
+import org.python.core.PyObject;
+import org.python.core.PyProxy;
+import org.python.core.PyReflectedConstructor;
+import org.python.core.PyReflectedFunction;
+
+
+/**
+ * Common code used by the Jython DCR instrumenters.
+ *
+ * @author Philip Aston
+ */
+abstract class AbstractJythonDCRInstrumenter extends AbstractDCRInstrumenter {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param context The DCR context.
+	 */
+	protected AbstractJythonDCRInstrumenter(DCRContext context) {
+		super(context);
+	}
+
+	/**
+	 * Extract and instrument the underlying Java methods for instrumentation.
+	 *
+	 * @param <T>
+	 *          Constructor<?> or Method
+	 * @param pyReflectedFunction
+	 *          The Jython object.
+	 * @return A list of Java methods or constructors.
+	 * @throws NonInstrumentableTypeException
+	 *           If the methods could not be extracted.
+	 */
+	@SuppressWarnings("unchecked")
+	private <T extends Member> List<T>
+	extractJavaMethods(PyReflectedFunction pyReflectedFunction)
+		throws NonInstrumentableTypeException {
+
+		// ReflectedArgs is package scope in Jython 2.2.1; use reflection
+		// to avoid compilation issues.
+
+		final Object[] argsList = pyReflectedFunction.argslist;
+		final int nargs = pyReflectedFunction.nargs;
+
+		final List<T> result = new ArrayList<T>(nargs);
+
+		for (int i = 0; i < nargs; ++i) {
+			final Object argument = argsList[i];
+
+			try {
+				final Field dataField = argument.getClass().getField("data");
+				dataField.setAccessible(true);
+				result.add((T)dataField.get(argument));
+			}
+			catch (Exception e) {
+				throw new NonInstrumentableTypeException(
+					e.getMessage() + " [" + pyReflectedFunction + "]",
+					e);
+			}
+		}
+
+		return result;
+	}
+
+	@Override protected boolean instrument(Object target,
+										   Recorder recorder,
+										   InstrumentationFilter filter)
+		throws NonInstrumentableTypeException {
+
+		if (target instanceof PyObject) {
+			disallowSelectiveFilter(filter);
+
+			// Jython object.
+			if (target instanceof PyInstance) {
+				transform(recorder, (PyInstance)target);
+			}
+			else if (target instanceof PyFunction) {
+				transform(recorder, (PyFunction)target);
+			}
+			else if (target instanceof PyMethod) {
+				final PyMethod pyMethod = (PyMethod)target;
+
+				// PyMethod is used for bound and unbound Python methods, and
+				// bound Java methods.
+
+				if (pyMethod.im_func instanceof PyReflectedFunction) {
+
+					// Its Java.
+
+					// Its possible im_func might be an unbound Java method or a Java
+					// constructor, but I can't find a way to trigger this. We always
+					// receive a PyReflectedMethod or PyReflectedConstructor directly.
+					// Here, we defensively cope with unbound methods, but not
+					// constructors.
+					transform(recorder,
+						(PyReflectedFunction)pyMethod.im_func,
+						pyMethod.im_self.__tojava__(Object.class));
+				}
+				else {
+					transform(recorder, pyMethod);
+				}
+			}
+			else if (target instanceof PyClass) {
+				transform(recorder, (PyClass)target);
+			}
+			else if (target instanceof PyReflectedConstructor) {
+				transform(recorder, (PyReflectedConstructor)target);
+			}
+			else if (target instanceof PyReflectedFunction) {
+				transform(recorder, (PyReflectedFunction)target, null);
+			}
+			else {
+				// Fail, rather than guess a generic approach.
+
+				// We should never be called with a PyType, since it will be
+				// converted to a PyClass or Java class by the implicit __tojava__()
+				// calls as part of dispatching to the record() implementation.
+
+				// Similarly PyObjectDerived will be converted to a Java class.
+
+				throw new NonInstrumentableTypeException("Unknown PyObject:" +
+					target.getClass());
+			}
+		}
+		else if (target instanceof PyProxy) {
+			disallowSelectiveFilter(filter);
+
+			transform(recorder, (PyProxy)target);
+		}
+		else {
+			// Let the Java instrumenter have a go.
+			return false;
+		}
+
+		return true;
+	}
+
+	private void disallowSelectiveFilter(InstrumentationFilter filter)
+		throws NonInstrumentableTypeException {
+
+		if (filter != ALL_INSTRUMENTATION) {
+			throw new NonInstrumentableTypeException(
+				"The Jython instrumenters do not support selective instrumenters");
+		}
+	}
+
+	protected abstract void transform(Recorder recorder, PyInstance target)
+		throws NonInstrumentableTypeException;
+
+	protected abstract void transform(Recorder recorder, PyFunction target)
+		throws NonInstrumentableTypeException;
+
+	protected abstract void transform(Recorder recorder, PyClass target)
+		throws NonInstrumentableTypeException;
+
+	protected abstract void transform(Recorder recorder, PyProxy target)
+		throws NonInstrumentableTypeException;
+
+	protected abstract void transform(Recorder recorder, PyMethod target)
+		throws NonInstrumentableTypeException;
+
+	protected final void transform(Recorder recorder,
+								   PyReflectedFunction target,
+								   Object instance)
+		throws NonInstrumentableTypeException {
+
+		final List<Method> reflectedArguments = extractJavaMethods(target);
+
+		if (instance != null) {
+			for (Method m : reflectedArguments) {
+
+				Class<?> c = instance.getClass();
+
+				// We want the instance's implementation, not the interface or
+				// superclass method used by the call site.
+				do {
+					try {
+						getContext().add(instance,
+							c.getDeclaredMethod(m.getName(),
+								m.getParameterTypes()),
+							TargetSource.FIRST_PARAMETER,
+							recorder);
+						break;
+					}
+					catch (NoSuchMethodException e) {
+						c = c.getSuperclass();
+					}
+				}
+				while (c != null);
+			}
+		}
+		else {
+			for (Method m : reflectedArguments) {
+				getContext().add(m.getDeclaringClass(),
+					m,
+					TargetSource.CLASS, recorder);
+			}
+		}
+	}
+
+	protected final void transform(Recorder recorder,
+								   PyReflectedConstructor target)
+		throws NonInstrumentableTypeException {
+
+		final List<Constructor<?>> reflectedArguments = extractJavaMethods(target);
+
+		for (Constructor<?> c : reflectedArguments) {
+			getContext().add(c.getDeclaringClass(), c, recorder);
+		}
+	}
+
+	protected final void instrumentPublicMethodsByName(
+		Object target,
+		String methodName,
+		Recorder recorder,
+		boolean includeSuperClassMethods)
+		throws NonInstrumentableTypeException {
+		instrumentPublicMethodsByName(target.getClass(),
+			target,
+			methodName,
+			TargetSource.FIRST_PARAMETER,
+			recorder,
+			includeSuperClassMethods);
+	}
+
+	protected final void instrumentPublicMethodsByName(
+		Class<?> targetClass,
+		Object target,
+		String methodName,
+		TargetSource targetSource,
+		Recorder recorder,
+		boolean includeSuperClassMethods)
+		throws NonInstrumentableTypeException {
+
+		// getMethods() includes superclass methods.
+		for (Method method : targetClass.getMethods()) {
+			if (!includeSuperClassMethods &&
+				targetClass != method.getDeclaringClass()) {
+				continue;
+			}
+
+			if (!method.getName().equals(methodName)) {
+				continue;
+			}
+
+			if (!targetSource.canApply(method)) {
+				continue;
+			}
+
+			getContext().add(target, method, targetSource, recorder);
+		}
+	}
+}

--- a/ngrinder-runtime/src/main/java/net/grinder/scriptengine/jython/instrumentation/dcr/Jython25Instrumenter.java
+++ b/ngrinder-runtime/src/main/java/net/grinder/scriptengine/jython/instrumentation/dcr/Jython25Instrumenter.java
@@ -1,0 +1,287 @@
+// Copyright (C) 2009 - 2011 Philip Aston
+// All rights reserved.
+//
+// This file is part of The Grinder software distribution. Refer to
+// the file LICENSE which is part of The Grinder distribution for
+// licensing details. The Grinder distribution is available on the
+// Internet at http://grinder.sourceforge.net/
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+// OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package net.grinder.scriptengine.jython.instrumentation.dcr;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import net.grinder.script.NonInstrumentableTypeException;
+import net.grinder.scriptengine.DCRContext;
+import net.grinder.scriptengine.Recorder;
+import net.grinder.util.weave.WeavingException;
+import net.grinder.util.weave.Weaver.TargetSource;
+
+import org.python.core.PyClass;
+import org.python.core.PyFunction;
+import org.python.core.PyInstance;
+import org.python.core.PyMethod;
+import org.python.core.PyObject;
+import org.python.core.PyProxy;
+import org.python.core.PyReflectedFunction;
+import org.python.core.ThreadState;
+
+
+/**
+ * DCR instrumenter for Jython 2.5.
+ *
+ * @author Philip Aston
+ */
+public final class Jython25Instrumenter extends AbstractJythonDCRInstrumenter {
+
+	private final Transformer<PyInstance> m_pyInstanceTransformer;
+	private final Transformer<PyFunction> m_pyFunctionTransformer;
+	private final Transformer<PyProxy> m_pyProxyTransformer;
+	private final Transformer<PyClass> m_pyClassTransformer;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param context The DCR context.
+	 * @throws WeavingException If it looks like Jython 2.5 isn't available.
+	 */
+	public Jython25Instrumenter(final DCRContext context)
+		throws WeavingException  {
+
+		super(context);
+
+		try {
+			final List<Method> methodsForPyFunction = new ArrayList<Method>();
+
+			for (Method method : PyFunction.class.getDeclaredMethods()) {
+				// Roughly identify the fundamental __call__ methods, i.e. those
+				// that call the actual func_code.
+				if (("__call__".equals(method.getName()) ||
+					// Add function__call__ for refactoring in Jython 2.5.2.
+					"function___call__".equals(method.getName())) &&
+					method.getParameterTypes().length >= 1 &&
+					method.getParameterTypes()[0] == ThreadState.class) {
+					methodsForPyFunction.add(method);
+				}
+			}
+
+			assertAtLeastOneMethod(methodsForPyFunction);
+
+			m_pyFunctionTransformer = new Transformer<PyFunction>() {
+				public void transform(Recorder recorder, PyFunction target)
+					throws NonInstrumentableTypeException {
+
+					for (Method method : methodsForPyFunction) {
+						context.add(target,
+							method,
+							TargetSource.FIRST_PARAMETER,
+							recorder);
+					}
+				}
+			};
+
+			final List<Method> methodsForPyInstance = new ArrayList<Method>();
+
+			for (Method method : PyFunction.class.getDeclaredMethods()) {
+				// Here we're finding the fundamental __call__ methods that also
+				// take an instance argument.
+				if ("__call__".equals(method.getName()) &&
+					method.getParameterTypes().length >= 2 &&
+					method.getParameterTypes()[0] == ThreadState.class &&
+					method.getParameterTypes()[1] == PyObject.class) {
+					methodsForPyInstance.add(method);
+				}
+			}
+
+			assertAtLeastOneMethod(methodsForPyInstance);
+
+			m_pyInstanceTransformer = new Transformer<PyInstance>() {
+				public void transform(Recorder recorder, PyInstance target)
+					throws NonInstrumentableTypeException {
+
+					for (Method method : methodsForPyInstance) {
+						context.add(target,
+							method,
+							TargetSource.THIRD_PARAMETER,
+							recorder);
+					}
+				}
+			};
+
+			final List<Method> methodsForPyMethod = new ArrayList<Method>();
+
+			for (Method method : PyMethod.class.getDeclaredMethods()) {
+				// Roughly identify the fundamental __call__ methods, i.e. those
+				// that call the actual func_code.
+				if (("__call__".equals(method.getName()) ||
+					// Add instancemethod___call__ for refactoring in Jython 2.5.2.
+					"instancemethod___call__".equals(method.getName())) &&
+					method.getParameterTypes().length >= 1 &&
+					method.getParameterTypes()[0] == ThreadState.class) {
+					methodsForPyMethod.add(method);
+				}
+			}
+
+			assertAtLeastOneMethod(methodsForPyMethod);
+
+			final Method pyReflectedFunctionCall =
+				PyReflectedFunction.class.getDeclaredMethod("__call__",
+					PyObject.class,
+					PyObject[].class,
+					String[].class);
+
+			// PyProxy is used for Jython objects that extend a Java class.
+			// We can't just use the Java wrapping, since then we'd miss the
+			// Jython methods.
+
+			// Need to look up this method dynamically, the return type differs
+			// between 2.2 and 2.5.
+			final Method pyProxyPyInstanceMethod =
+				PyProxy.class.getDeclaredMethod("_getPyInstance");
+
+			m_pyProxyTransformer = new Transformer<PyProxy>() {
+				public void transform(Recorder recorder, PyProxy target)
+					throws NonInstrumentableTypeException {
+					final PyObject pyInstance;
+
+					try {
+						pyInstance = (PyObject) pyProxyPyInstanceMethod.invoke(target);
+					}
+					catch (Exception e) {
+						throw new NonInstrumentableTypeException(
+							"Could not call _getPyInstance", e);
+					}
+
+					for (Method method : methodsForPyInstance) {
+						context.add(pyInstance,
+							method,
+							TargetSource.THIRD_PARAMETER,
+							recorder);
+					}
+
+					context.add(pyInstance,
+						pyReflectedFunctionCall,
+						TargetSource.SECOND_PARAMETER,
+						recorder);
+				}
+			};
+
+			final Method pyClassCall =
+				PyClass.class.getDeclaredMethod("__call__",
+					PyObject[].class,
+					String[].class);
+
+			m_pyClassTransformer = new Transformer<PyClass>() {
+				public void transform(Recorder recorder, PyClass target)
+					throws NonInstrumentableTypeException {
+					context.add(target,
+						pyClassCall,
+						TargetSource.FIRST_PARAMETER,
+						recorder);
+				}
+			};
+		}
+		catch (NoSuchMethodException e) {
+			throw new WeavingException("Jython 2.5 not found", e);
+		}
+	}
+
+	private static void assertAtLeastOneMethod(List<Method> methods)
+		throws WeavingException {
+		if (methods.size() == 0) {
+			throw new WeavingException("Jython 2.5 not found");
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override public String getDescription() {
+		return "byte code transforming instrumenter for Jython 2.5";
+	}
+
+	private interface Transformer<T> {
+		void transform(Recorder recorder, T target)
+			throws NonInstrumentableTypeException;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override protected void transform(Recorder recorder, PyInstance target)
+		throws NonInstrumentableTypeException {
+		m_pyInstanceTransformer.transform(recorder, target);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override protected void transform(Recorder recorder, PyFunction target)
+		throws NonInstrumentableTypeException {
+		m_pyFunctionTransformer.transform(recorder, target);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override protected void transform(Recorder recorder, PyClass target)
+		throws NonInstrumentableTypeException {
+		m_pyClassTransformer.transform(recorder, target);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override protected void transform(Recorder recorder, PyProxy target)
+		throws NonInstrumentableTypeException {
+		m_pyProxyTransformer.transform(recorder, target);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override protected void transform(Recorder recorder, PyMethod target)
+		throws NonInstrumentableTypeException {
+
+		// PyMethod is a wrapper around a callable. Sometimes Jython bypasses
+		// the PyMethod (e.g. dispatch of self.foo() calls). Sometimes there
+		// are multiple PyMethods that refer to the same callable.
+
+		// In the common case, the callable is a PyFunction wrapping some PyCode.
+		// Experimentation shows that there'll be  a single PyFunction. However,
+		// there's nothing that forces this to be true - some code path might
+		// create a different PyFunction referring to the same code. Also, we must
+		// cope with other types of callable. I guess I could identify
+		// PyFunction's and dispatch on their im_code should this become an issue.
+
+		if (target.im_self == null) {
+			// Unbound method.
+			instrumentPublicMethodsByName(target.im_func,
+				"__call__",
+				recorder,
+				false);
+		}
+		else {
+			instrumentPublicMethodsByName(target.im_func.getClass(),
+				target.im_self,
+				"__call__",
+				TargetSource.THIRD_PARAMETER,
+				recorder,
+				false);
+		}
+	}
+}

--- a/ngrinder-runtime/src/main/java/net/grinder/scriptengine/jython/instrumentation/dcr/Jython27Instrumenter.java
+++ b/ngrinder-runtime/src/main/java/net/grinder/scriptengine/jython/instrumentation/dcr/Jython27Instrumenter.java
@@ -21,32 +21,24 @@
 
 package net.grinder.scriptengine.jython.instrumentation.dcr;
 
+import net.grinder.script.NonInstrumentableTypeException;
+import net.grinder.scriptengine.DCRContext;
+import net.grinder.scriptengine.Recorder;
+import net.grinder.util.weave.Weaver.TargetSource;
+import net.grinder.util.weave.WeavingException;
+import org.python.core.*;
+
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
-import net.grinder.script.NonInstrumentableTypeException;
-import net.grinder.scriptengine.DCRContext;
-import net.grinder.scriptengine.Recorder;
-import net.grinder.util.weave.WeavingException;
-import net.grinder.util.weave.Weaver.TargetSource;
-
-import org.python.core.PyClass;
-import org.python.core.PyFunction;
-import org.python.core.PyInstance;
-import org.python.core.PyMethod;
-import org.python.core.PyObject;
-import org.python.core.PyProxy;
-import org.python.core.PyReflectedFunction;
-import org.python.core.ThreadState;
-
 
 /**
- * DCR instrumenter for Jython 2.5.
+ * DCR instrumenter for Jython 2.7 (modified for nGrinder)
  *
  * @author Philip Aston
  */
-public final class Jython25Instrumenter extends AbstractJythonDCRInstrumenter {
+public final class Jython27Instrumenter extends AbstractJythonDCRInstrumenter {
 
 	private final Transformer<PyInstance> m_pyInstanceTransformer;
 	private final Transformer<PyFunction> m_pyFunctionTransformer;
@@ -57,9 +49,9 @@ public final class Jython25Instrumenter extends AbstractJythonDCRInstrumenter {
 	 * Constructor.
 	 *
 	 * @param context The DCR context.
-	 * @throws WeavingException If it looks like Jython 2.5 isn't available.
+	 * @throws WeavingException If it looks like Jython 2.7 isn't available.
 	 */
-	public Jython25Instrumenter(final DCRContext context)
+	public Jython27Instrumenter(final DCRContext context)
 		throws WeavingException  {
 
 		super(context);
@@ -196,14 +188,14 @@ public final class Jython25Instrumenter extends AbstractJythonDCRInstrumenter {
 			};
 		}
 		catch (NoSuchMethodException e) {
-			throw new WeavingException("Jython 2.5 not found", e);
+			throw new WeavingException("Jython 2.7 not found", e);
 		}
 	}
 
 	private static void assertAtLeastOneMethod(List<Method> methods)
 		throws WeavingException {
 		if (methods.size() == 0) {
-			throw new WeavingException("Jython 2.5 not found");
+			throw new WeavingException("Jython 2.7 not found");
 		}
 	}
 
@@ -211,7 +203,7 @@ public final class Jython25Instrumenter extends AbstractJythonDCRInstrumenter {
 	 * {@inheritDoc}
 	 */
 	@Override public String getDescription() {
-		return "byte code transforming instrumenter for Jython 2.5";
+		return "byte code transforming instrumenter for Jython 2.7";
 	}
 
 	private interface Transformer<T> {
@@ -268,16 +260,16 @@ public final class Jython25Instrumenter extends AbstractJythonDCRInstrumenter {
 		// cope with other types of callable. I guess I could identify
 		// PyFunction's and dispatch on their im_code should this become an issue.
 
-		if (target.im_self == null) {
+		if (target.__self__ == null) {
 			// Unbound method.
-			instrumentPublicMethodsByName(target.im_func,
+			instrumentPublicMethodsByName(target.__func__,
 				"__call__",
 				recorder,
 				false);
 		}
 		else {
-			instrumentPublicMethodsByName(target.im_func.getClass(),
-				target.im_self,
+			instrumentPublicMethodsByName(target.__func__.getClass(),
+				target.__self__,
 				"__call__",
 				TargetSource.THIRD_PARAMETER,
 				recorder,


### PR DESCRIPTION
Because the ASM version has been raised in [this](https://github.com/naver/ngrinder/pull/677/commits/80a8df1850e4d72a7c6f84d3df302c1b9fcd54a7) commit when you run Jython scripts with `jython-standalone:2.5.3` It emits `java.lang.VerifyError` at runtime. (It seems to be occurred when weaving)
So, bumped jython-standalone version up for compatibility with the latest version of ASM.

> This PR required more testing and must be merged before https://github.com/naver/ngrinder/pull/677