### PR TITLE
Fix not working remember-me

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/config/SecurityConfig.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/config/SecurityConfig.java
@@ -78,6 +78,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
 	private final PluggablePreAuthFilter pluggablePreAuthFilter;
 
+	private static final String REMEMBER_ME_KEY = "ngrinder";
+	private static final String REMEMBER_ME_COOKIE_NAME = "ngrinder-remember-me";
+
 	@Bean
 	@Override
 	protected AuthenticationManager authenticationManager() throws Exception {
@@ -93,7 +96,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
 	@Bean
 	public TokenBasedRememberMeServices rememberMeServices() {
-		return new TokenBasedRememberMeServices("ngrinder", ngrinderUserDetailsService);
+		TokenBasedRememberMeServices tokenBasedRememberMeServices = new TokenBasedRememberMeServices(REMEMBER_ME_KEY, ngrinderUserDetailsService);
+		tokenBasedRememberMeServices.setCookieName(REMEMBER_ME_COOKIE_NAME);
+		return tokenBasedRememberMeServices;
 	}
 
 	/**
@@ -161,14 +166,15 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 			.logout()
 			.logoutRequestMatcher(new AntPathRequestMatcher("/logout"))
 			.logoutSuccessUrl("/")
-			.deleteCookies("JSESSIONID","switchUser")
+			.deleteCookies("JSESSIONID", "switchUser")
 			.invalidateHttpSession(true)
 			.and()
 			.sessionManagement()
 			.sessionFixation().newSession()
 			.and()
 			.rememberMe()
-			.key("ngrinder")
+			.rememberMeCookieName(REMEMBER_ME_COOKIE_NAME)
+			.key(REMEMBER_ME_KEY)
 			.userDetailsService(ngrinderUserDetailsService)
 			.and()
 			.csrf().disable().exceptionHandling().authenticationEntryPoint(delegatingAuthenticationEntryPoint())

--- a/ngrinder-frontend/src/js/components/Login.vue
+++ b/ngrinder-frontend/src/js/components/Login.vue
@@ -17,7 +17,7 @@
                     </div>
 
                     <div class="prompt">
-                        <input type="checkbox" class="checkbox remember-me" name='_spring_security_remember_me'>
+                        <input type="checkbox" class="checkbox remember-me" name="remember-me">
                         <span>Remember Me</span>
                         <select class="form-control native-language" name="native_language" v-model="userLanguage">
                             <option value="en">English</option>


### PR DESCRIPTION
Fix not working remember-me feature.

If you check the remember-me checkbox when you try to log-in the ngrinder, You can stay logged state when the session is expired or even the controller is restarted.