### PR TITLE
Bump axios version up to avoid vulnerability

### DIFF
--- a/ngrinder-frontend/package.json
+++ b/ngrinder-frontend/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "html-entities": "1.3.1",
     "select2": "^3.5.1",
-    "axios": "^0.19.0",
+    "axios": "^0.21.1",
     "base64-js": "^1.2.1",
     "billboard.js": "^1.11.0",
     "bootbox": "^5.2.0",


### PR DESCRIPTION
Axios that we are using now, It has a critical [vulnerability](https://github.com/naver/ngrinder/security/dependabot/ngrinder-frontend/package.json/axios/open).
so that I bumped axios version up to the recommended version(patched version) of github security bot.