### PR TITLE
Change default H2 database url in easy clustering mode

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/config/Database.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/config/Database.java
@@ -62,6 +62,7 @@ public enum Database {
 			final String databaseURL = databaseProperties.getProperty(DatabaseConfig.PROP_DATABASE_URL);
 			if (databaseURL.startsWith("tcp://")) {
 				format = "jdbc:h2:" + databaseURL;
+				setClusterSupport(true);
 			}
 			if (databaseProperties.exist(PROP_DATABASE_UNIT_TEST)) {
 				format = format + ";LOCK_MODE=0";
@@ -84,7 +85,7 @@ public enum Database {
 	private final String urlTemplate;
 	private final String jdbcDriverName;
 	private final String dialect;
-	private final boolean clusterSupport;
+	private boolean clusterSupport;
 
 	/**
 	 * Constructor with cluster mode true.
@@ -207,5 +208,9 @@ public enum Database {
 	 */
 	public boolean isClusterSupport() {
 		return clusterSupport;
+	}
+
+	public void setClusterSupport(boolean clusterSupport) {
+		this.clusterSupport = clusterSupport;
 	}
 }

--- a/ngrinder-controller/src/main/java/org/ngrinder/starter/NGrinderControllerStarter.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/starter/NGrinderControllerStarter.java
@@ -117,7 +117,7 @@ public class NGrinderControllerStarter extends SpringBootServletInitializer {
 							+ ".\nPlease run the h2 TcpServer in advance\n"
 							+ "or set the correct -database-host and -database-port parameters");
 					}
-					System.setProperty("database.url", "tcp://" + this.databaseHost + ":" + databasePort + "/db/ngrinder");
+					System.setProperty("database.url", "tcp://" + databaseHost + ":" + databasePort + "/~/db/ngrinder");
 				} else {
 					if (databasePort == null) {
 						databasePort = 3306;


### PR DESCRIPTION
If use implicitly relative path to H2 database url, It emits error and required additional options.
To make UX easier,  I change the default H2  database url to use relative path of user home when user running on easy clustering mode.

![image](https://user-images.githubusercontent.com/14273601/103841967-13c88b00-50d8-11eb-8091-de04dbbf7542.png)
