### PR TITLE
Fix easy clustering

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/config/Config.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/config/Config.java
@@ -150,8 +150,12 @@ public class Config extends AbstractConfig implements ControllerConstants, Clust
 	}
 
 	private boolean resolveClusterMode() {
-		String mode = getClusterProperties().getProperty(PROP_CLUSTER_MODE, "none");
+		String mode = getClusterMode();
 		return !"none".equals(mode) || getClusterProperties().getPropertyBoolean(PROP_CLUSTER_ENABLED);
+	}
+
+	public String getClusterMode() {
+		return getClusterProperties().getProperty(PROP_CLUSTER_MODE, "none");
 	}
 
 	/**

--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/config/Database.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/config/Database.java
@@ -62,6 +62,7 @@ public enum Database {
 			final String databaseURL = databaseProperties.getProperty(DatabaseConfig.PROP_DATABASE_URL);
 			if (databaseURL.startsWith("tcp://")) {
 				format = "jdbc:h2:" + databaseURL;
+				setClusterSupport(true);
 			}
 			if (databaseProperties.exist(PROP_DATABASE_UNIT_TEST)) {
 				format = format + ";LOCK_MODE=0";
@@ -84,7 +85,7 @@ public enum Database {
 	private final String urlTemplate;
 	private final String jdbcDriverName;
 	private final String dialect;
-	private final boolean clusterSupport;
+	private boolean clusterSupport;
 
 	/**
 	 * Constructor with cluster mode true.
@@ -207,5 +208,9 @@ public enum Database {
 	 */
 	public boolean isClusterSupport() {
 		return clusterSupport;
+	}
+
+	public void setClusterSupport(boolean clusterSupport) {
+		this.clusterSupport = clusterSupport;
 	}
 }

--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/ConsoleManager.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/ConsoleManager.java
@@ -34,7 +34,9 @@ import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import static net.grinder.util.NetworkUtils.DEFAULT_LOCAL_HOST_ADDRESS;
 import static net.grinder.util.NetworkUtils.getAvailablePorts;
+import static org.apache.commons.lang.StringUtils.defaultIfEmpty;
 import static org.ngrinder.common.constant.ControllerConstants.*;
 import static org.ngrinder.common.util.ExceptionUtils.processException;
 import static org.ngrinder.common.util.NoOp.noOp;
@@ -70,7 +72,7 @@ public class ConsoleManager {
 	public void init() {
 		int consoleSize = getConsoleSize();
 		consoleQueue = new ArrayBlockingQueue<>(consoleSize);
-		final String currentIP = config.getCurrentIP();
+		final String currentIP = defaultIfEmpty(config.getCurrentIP(), DEFAULT_LOCAL_HOST_ADDRESS);
 		for (int port : getAvailablePorts(currentIP, consoleSize, getConsolePortBase(), MAX_PORT_NUMBER)) {
 			final ConsoleEntry consoleEntry = new ConsoleEntry(currentIP, port);
 			try {

--- a/ngrinder-controller/src/main/java/org/ngrinder/starter/NGrinderControllerStarter.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/starter/NGrinderControllerStarter.java
@@ -117,7 +117,7 @@ public class NGrinderControllerStarter extends SpringBootServletInitializer {
 							+ ".\nPlease run the h2 TcpServer in advance\n"
 							+ "or set the correct -database-host and -database-port parameters");
 					}
-					System.setProperty("database.url", "tcp://" + this.databaseHost + ":" + databasePort + "/db/ngrinder");
+					System.setProperty("database.url", "tcp://" + databaseHost + ":" + databasePort + "/~/db/ngrinder");
 				} else {
 					if (databasePort == null) {
 						databasePort = 3306;

--- a/ngrinder-controller/src/main/java/org/ngrinder/starter/NGrinderControllerStarter.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/starter/NGrinderControllerStarter.java
@@ -68,9 +68,8 @@ public class NGrinderControllerStarter extends SpringBootServletInitializer {
 					"it can only communicate with the other cluster members in the same machine.")
 			private String clusterHost = null;
 
-			@Parameter(names = {"-clp", "--cluster-port"}, required = true,
-				description = "This cluster member's cluster communication port. Each cluster member should " +
-					"be run with unique cluster port.",
+			@Parameter(names = {"-clp", "--cluster-port"},
+				description = "Deprecated from 3.5.4, the cluster communication port will be resolved automatically in easy clustering",
 				validateValueWith = PortAvailabilityValidator.class)
 			private Integer clusterPort = null;
 
@@ -104,7 +103,6 @@ public class NGrinderControllerStarter extends SpringBootServletInitializer {
 				if (clusterHost != null) {
 					System.setProperty("cluster.host", clusterHost);
 				}
-				System.setProperty("cluster.port", clusterPort.toString());
 				System.setProperty("cluster.region", region);
 				System.setProperty("controller.controller_port", controllerPort.toString());
 				System.setProperty("database.type", databaseType);


### PR DESCRIPTION
Make easy clustering only run in a single machine and `cluster-port ` is not a required option anymore.
If you run ngrinder on easy clustering It automatically clustered to localhost each other.