### PR TITLE
Support dynamic modification of script template

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/common/model/Home.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/common/model/Home.java
@@ -42,6 +42,8 @@ import static org.ngrinder.common.util.Preconditions.checkNotNull;
 public class Home {
 
 	// HOME_PATH
+	public static final String PATH_SCRIPT_TEMPLATE_DIRECTORY = "/script_template";
+
 	private static final String PATH_PLUGIN = "plugins";
 	private static final String PATH_SCRIPT = "script";
 	private static final String PATH_USER_REPO = "repos";
@@ -267,6 +269,10 @@ public class Home {
 		}
 		String folderName = String.format("%d_%d%s%s", numericId, numericId + 999, File.separator, id);
 		return new File(getPerfTestDirectory(), folderName);
+	}
+
+	public File getScriptTemplateDirectory() {
+		return new File(directory, PATH_SCRIPT_TEMPLATE_DIRECTORY);
 	}
 
 	/**

--- a/ngrinder-controller/src/main/java/org/ngrinder/common/util/FileUtils.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/common/util/FileUtils.java
@@ -14,23 +14,22 @@
 package org.ngrinder.common.util;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
 
-import static org.apache.commons.io.IOUtils.copy;
+import static org.apache.commons.io.FileUtils.*;
 
 /**
  * Convenient File utilities.
  *
  * @since 3.1
  */
+@Slf4j
 public abstract class FileUtils {
-	private static final Logger LOGGER = LoggerFactory.getLogger(FileUtils.class);
 
 	/**
 	 * Copy the given resource to the given file.
@@ -40,11 +39,15 @@ public abstract class FileUtils {
 	 * @since 3.2
 	 */
 	public static void copyResourceToFile(String resourcePath, File file) {
-		try (InputStream io = new ClassPathResource(resourcePath).getInputStream();
-			 FileOutputStream fos = new FileOutputStream(file)) {
-			copy(io, fos);
+		copyResourceToFile(new ClassPathResource(resourcePath), file);
+	}
+
+	public static void copyResourceToFile(Resource resource, File file) {
+		try (InputStream io = resource.getInputStream()) {
+			copyToFile(io, file);
 		} catch (IOException e) {
-			LOGGER.error("error while writing {}", resourcePath, e);
+			log.error("error while writing {}", resource.getFilename(), e);
 		}
 	}
+
 }

--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/config/Config.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/config/Config.java
@@ -23,6 +23,7 @@ import org.ngrinder.common.constant.ClusterConstants;
 import org.ngrinder.common.constant.ControllerConstants;
 import org.ngrinder.common.constants.InternalConstants;
 import org.ngrinder.common.exception.ConfigurationException;
+import org.ngrinder.common.exception.NGrinderRuntimeException;
 import org.ngrinder.common.model.Home;
 import org.ngrinder.common.util.FileWatchdog;
 import org.ngrinder.common.util.PropertiesKeyMapper;
@@ -51,10 +52,13 @@ import java.util.Properties;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static net.grinder.util.NoOp.noOp;
-import static org.apache.commons.io.FileUtils.readFileToString;
+import static org.apache.commons.io.FileUtils.*;
 import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.ngrinder.common.constant.DatabaseConstants.PROP_DATABASE_UNIT_TEST;
 import static org.ngrinder.common.constants.GrinderConstants.GRINDER_SECURITY_LEVEL_NORMAL;
+import static org.ngrinder.common.model.Home.PATH_SCRIPT_TEMPLATE_DIRECTORY;
+import static org.ngrinder.common.util.FileUtils.copyResourceToFile;
+import static org.ngrinder.common.util.PathUtils.getSubPath;
 import static org.ngrinder.common.util.Preconditions.checkNotNull;
 
 /**
@@ -124,6 +128,7 @@ public class Config extends AbstractConfig implements ControllerConstants, Clust
 			home.init();
 			exHome = resolveExHome();
 			copyDefaultConfigurationFiles();
+			copyScriptTemplates();
 			loadInternalProperties();
 			loadProperties();
 			initHomeMonitor();
@@ -260,6 +265,31 @@ public class Config extends AbstractConfig implements ControllerConstants, Clust
 		ResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
 		Resource[] resources = resolver.getResources("classpath*:ngrinder_home_template/*");
 		home.copyFrom(resources);
+	}
+
+	private void copyScriptTemplates() {
+		File scriptTemplateDirectory = home.getScriptTemplateDirectory();
+		if (!scriptTemplateDirectory.exists()) {
+			try {
+				ResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+				Resource[] resources = resolver.getResources("classpath*:script_template/**/*.*");
+				for (Resource resource : resources) {
+					String scriptTemplatePath = home.getScriptTemplateDirectory().getAbsolutePath();
+					scriptTemplatePath += getSubPath(PATH_SCRIPT_TEMPLATE_DIRECTORY, resource.getURL().getPath());
+					copyResourceToFile(resource, new File(scriptTemplatePath));
+				}
+			} catch (IOException e) {
+				throw new NGrinderRuntimeException("Error while copying script templates.", e);
+			}
+		}
+	}
+
+	public File getHomeScriptTemplateDirectory() {
+		File scriptTemplateDirectory = home.getScriptTemplateDirectory();
+		if (!scriptTemplateDirectory.exists()) {
+			copyScriptTemplates();
+		}
+		return scriptTemplateDirectory;
 	}
 
 	/**

--- a/ngrinder-controller/src/main/java/org/ngrinder/script/handler/ScriptHandler.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/script/handler/ScriptHandler.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import freemarker.template.Configuration;
 import freemarker.template.DefaultObjectWrapper;
 import freemarker.template.Template;
+import freemarker.template.TemplateNotFoundException;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FilenameUtils;
@@ -27,6 +28,7 @@ import org.ngrinder.common.exception.NGrinderRuntimeException;
 import org.ngrinder.common.exception.PerfTestPrepareException;
 import org.ngrinder.common.util.PathUtils;
 import org.ngrinder.common.util.PropertiesWrapper;
+import org.ngrinder.infra.config.Config;
 import org.ngrinder.model.PerfTest;
 import org.ngrinder.model.User;
 import org.ngrinder.script.model.FileEntry;
@@ -89,6 +91,10 @@ public abstract class ScriptHandler implements ControllerConstants {
 	@Autowired
 	@JsonIgnore
 	private GitHubFileEntryRepository gitHubFileEntryRepository;
+
+	@Autowired
+	@JsonIgnore
+	private Config config;
 
 	/**
 	 * Get the display order of {@link ScriptHandler}s.
@@ -327,11 +333,12 @@ public abstract class ScriptHandler implements ControllerConstants {
 	 * @return generated string
 	 */
 	public String getScriptTemplate(Map<String, Object> values) {
+		String templateFileName = "basic_template_" + getExtension() + ".ftl";
 		try {
 			Configuration freemarkerConfig = new Configuration(DEFAULT_INCOMPATIBLE_IMPROVEMENTS);
 			freemarkerConfig.setObjectWrapper(new DefaultObjectWrapper(DEFAULT_INCOMPATIBLE_IMPROVEMENTS));
-			freemarkerConfig.setClassForTemplateLoading(this.getClass() , "/script_template");
-			Template template = freemarkerConfig.getTemplate("basic_template_" + getExtension() + ".ftl");
+			freemarkerConfig.setDirectoryForTemplateLoading(config.getHomeScriptTemplateDirectory());
+			Template template = freemarkerConfig.getTemplate(templateFileName);
 			StringWriter writer = new StringWriter();
 			template.process(values, writer);
 			return writer.toString();

--- a/ngrinder-controller/src/main/java/org/ngrinder/script/service/FileEntryService.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/script/service/FileEntryService.java
@@ -41,11 +41,10 @@ import javax.annotation.PostConstruct;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
 import static org.apache.commons.compress.utils.CharsetNames.UTF_8;
 import static org.ngrinder.common.constant.CacheConstants.DIST_CACHE_FILE_ENTRIES;
@@ -273,7 +272,7 @@ public class FileEntryService {
 	 * @param path the path
 	 */
 	public void delete(User user, String path) {
-		fileEntityRepository.delete(user, newArrayList(path));
+		fileEntityRepository.delete(user, new ArrayList<>(singletonList(path)));
 	}
 
 	String getPathFromUrl(String urlString) {

--- a/ngrinder-controller/src/main/resources/script_template/groovy_gradle/src/main/java/TestRunner.groovy
+++ b/ngrinder-controller/src/main/resources/script_template/groovy_gradle/src/main/java/TestRunner.groovy
@@ -1,0 +1,2 @@
+// Empty file
+// This template will be filled out with the contents of 'script_template_groovy.ftl'

--- a/ngrinder-frontend/src/js/components/script/modal/CreateScriptModal.vue
+++ b/ngrinder-frontend/src/js/components/script/modal/CreateScriptModal.vue
@@ -103,10 +103,12 @@
 </template>
 
 <script>
+    import { Mixins } from 'vue-mixin-decorator';
     import { Component } from 'vue-property-decorator';
     import ModalBase from '../../common/modal/ModalBase.vue';
     import ControlGroup from '../../common/ControlGroup.vue';
     import ScriptOption from './ScriptOption.vue';
+    import MessagesMixin from '../../common/mixin/MessagesMixin.vue';
 
     const resolve = (source, relative) => {
         const removeAppendedSlash = path => (path.startsWith('/') ? path.slice(1) : path);
@@ -127,7 +129,7 @@
             validator: 'new',
         },
     })
-    export default class CreateScriptModal extends ModalBase {
+    export default class CreateScriptModal extends Mixins(ModalBase, MessagesMixin) {
         fileName = '';
         handlers = [];
         scriptHandler = {};
@@ -191,7 +193,7 @@
                     } else {
                         this.$router.push(resolve('/script/detail', res.data.file.path));
                     }
-                });
+                }).catch(err => this.showErrorMsg(err.response.data.message));
         }
 
         focusToInvalidField() {


### PR DESCRIPTION
In some cases, users want to modify the script template dynamically. so that I changed the way how ngrinder get the template files from resources.

1. When ngrinder is started, the `script_template` resources are copied to under `NGRINDER_HOME`. if `script_template` folder already exists in `NGRINDER_HOME` this step is skipped.
2. ngrinder get template resources from `NGRINDER_HOME/script_template` not from classpath: