### PR TITLE
Add ES5 checking task to build cycle

### DIFF
--- a/ngrinder-controller/build.gradle
+++ b/ngrinder-controller/build.gradle
@@ -114,4 +114,5 @@ test {
 
 tasks.bootWar.dependsOn convert_cr_lf
 
-tasks.processResources.dependsOn tasks.getByPath(":ngrinder-frontend:webpack")
+tasks.processResources.finalizedBy tasks.getByPath(":ngrinder-frontend:webpack")
+tasks.processResources.finalizedBy tasks.getByPath(":ngrinder-frontend:checkES5")

--- a/ngrinder-frontend/build.gradle
+++ b/ngrinder-frontend/build.gradle
@@ -1,9 +1,9 @@
 plugins {
-    id "com.github.node-gradle.node" version "2.2.2"
+    id "com.github.node-gradle.node" version "2.2.4"
 }
 
 node {
-    version = "12.16.2"
+    version = "14.15.4"
     // Enabled the automatic download. False is the default (for now).
     download = true
 }
@@ -13,4 +13,9 @@ task webpack(dependsOn: "npmInstall", type: NodeTask) {
     if (profile) {
         args = ["--$profile"]
     }
+}
+
+task checkES5(type: NpxTask) {
+    command = "es-check"
+    args = ["es5", "../ngrinder-controller/build/classes/main/static/js/app.js", "--verbose"]
 }

--- a/ngrinder-frontend/webpack.config.js
+++ b/ngrinder-frontend/webpack.config.js
@@ -83,6 +83,7 @@ module.exports = function (env) {
                             /(d3-.*)$/,
                             /(strip-.*)$/,
                             /(.*json.*)$/,
+                            /(vuejs-datepicker.*)$/,
                         ],
                     },
                     use: [


### PR DESCRIPTION
1. Check es5 syntax at build time.
2. transpiled vuejs-datepicker because it contains the `const` keyword.

> const is fully supported by IE11 but caught by es-check. There seems to be no option to skip certain keywords.