### PR TITLE
Look up controller ip from dns when agent re-tries to connect to controller

### DIFF
--- a/ngrinder-core/src/main/java/net/grinder/AgentController.java
+++ b/ngrinder-core/src/main/java/net/grinder/AgentController.java
@@ -46,6 +46,7 @@ import java.util.Arrays;
 import java.util.Timer;
 import java.util.TimerTask;
 
+import static net.grinder.util.NetworkUtils.getIP;
 import static org.ngrinder.common.constants.InternalConstants.PROP_INTERNAL_NGRINDER_VERSION;
 import static org.ngrinder.common.util.NoOp.noOp;
 import static org.ngrinder.common.util.Preconditions.checkNotNull;
@@ -125,7 +126,9 @@ public class AgentController implements Agent, AgentConstants {
 							connector = m_connectorFactory.create(agentConfig.getConnectionAgentPort());
 							occupyConnectionAgentSocket();
 						} else {
-							connector = m_connectorFactory.create(agentConfig.getControllerIP(), agentConfig.getControllerPort());
+							String controllerIP = getIP(agentConfig.getControllerHost());
+							agentConfig.setControllerIP(controllerIP);
+							connector = m_connectorFactory.create(controllerIP, agentConfig.getControllerPort());
 						}
 
 						try {

--- a/ngrinder-core/src/main/java/net/grinder/engine/agent/AgentImplementationEx.java
+++ b/ngrinder-core/src/main/java/net/grinder/engine/agent/AgentImplementationEx.java
@@ -27,7 +27,6 @@ import net.grinder.common.GrinderProperties;
 import net.grinder.common.GrinderProperties.PersistenceException;
 import net.grinder.common.processidentity.ProcessReport;
 import net.grinder.communication.*;
-import net.grinder.console.ConsoleFoundation;
 import net.grinder.engine.common.ConnectorFactory;
 import net.grinder.engine.common.EngineException;
 import net.grinder.engine.common.ScriptLocation;

--- a/ngrinder-core/src/main/java/org/ngrinder/NGrinderAgentStarter.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/NGrinderAgentStarter.java
@@ -48,6 +48,8 @@ public class NGrinderAgentStarter implements AgentConstants, CommonConstants {
 
 	private static final Logger LOG = LoggerFactory.getLogger("starter");
 
+	private static final String NETWORK_ADDRESS_CACHE_TTL_SECOND = "20";
+
 	private AgentConfig agentConfig;
 
 	private AgentControllerDaemon agentController;
@@ -132,8 +134,8 @@ public class NGrinderAgentStarter implements AgentConstants, CommonConstants {
 		if (agentConfig.isConnectionMode()) {
 			LOG.info("waiting for connection on {}:{}", agentConfig.getBroadcastIP(), agentConfig.getConnectionAgentPort());
 		} else {
-			String controllerIP = getIP(agentConfig.getControllerIP());
-			agentConfig.setControllerHost(controllerIP);
+			String controllerIP = getIP(agentConfig.getControllerHost());
+			agentConfig.setControllerIP(controllerIP);
 			LOG.info("connecting to controller {}:{}", controllerIP, agentConfig.getControllerPort());
 		}
 
@@ -204,6 +206,9 @@ public class NGrinderAgentStarter implements AgentConstants, CommonConstants {
 			return;
 		}
 		starter.checkDuplicatedRun(startMode);
+
+		java.security.Security.setProperty("networkaddress.cache.ttl", NETWORK_ADDRESS_CACHE_TTL_SECOND);
+
 		if (startMode.equalsIgnoreCase("agent")) {
 			starter.startAgent();
 		} else if (startMode.equalsIgnoreCase("monitor")) {

--- a/ngrinder-core/src/main/java/org/ngrinder/infra/AgentConfig.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/infra/AgentConfig.java
@@ -37,6 +37,7 @@ import java.util.Set;
 
 import static net.grinder.util.NetworkUtils.DEFAULT_LOCAL_HOST_ADDRESS;
 import static org.apache.commons.io.FileUtils.deleteQuietly;
+import static org.apache.commons.lang.StringUtils.defaultIfEmpty;
 import static org.apache.commons.lang.StringUtils.trimToEmpty;
 import static org.ngrinder.common.util.ExceptionUtils.processException;
 import static org.ngrinder.common.util.NoOp.noOp;
@@ -59,6 +60,7 @@ public class AgentConfig implements AgentConstants, MonitorConstants, CommonCons
 	private PropertiesWrapper monitorProperties;
 	private PropertiesWrapper commonProperties;
 	private PropertiesWrapper internalProperties;
+	private String controllerIP;
 
 	private final PropertiesKeyMapper internalPropertyMapper = PropertiesKeyMapper.create("internal-properties.map");
 	private final PropertiesKeyMapper agentPropertyMapper = PropertiesKeyMapper.create("agent-properties.map");
@@ -318,12 +320,16 @@ public class AgentConfig implements AgentConstants, MonitorConstants, CommonCons
 		return getMonitorProperties().getProperty(PROP_MONITOR_BINDING_IP);
 	}
 
-	public String getControllerIP() {
+	public String getControllerHost() {
 		return getAgentProperties().getProperty(PROP_AGENT_CONTROLLER_HOST, DEFAULT_LOCAL_HOST_ADDRESS);
 	}
 
-	public void setControllerHost(String host) {
-		getAgentProperties().addProperty(PROP_AGENT_CONTROLLER_HOST, host);
+	public void setControllerIP(String ip) {
+		controllerIP = ip;
+	}
+
+	public String getControllerIP() {
+		return defaultIfEmpty(controllerIP, DEFAULT_LOCAL_HOST_ADDRESS);
 	}
 
 	public int getControllerPort() {


### PR DESCRIPTION
To support dynamic IP to a specific domain, when the agent re-reties to connect to a disconnected controller  It looks up controller IP from DNS.

> TTL properties refered to [AWS developer guide](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/java-dg-jvm-ttl.html)