### PR TITLE
Fix cannot search user with two characters

### DIFF
--- a/ngrinder-frontend/src/js/components/user/UserInfo.vue
+++ b/ngrinder-frontend/src/js/components/user/UserInfo.vue
@@ -154,7 +154,7 @@
             if (this.config.allowShareChange) {
                 this.followerSelect2Option = {
                     multiple: true,
-                    minimumInputLength: 3,
+                    minimumInputLength: 2,
                     ajax: {
                         url: '/user/api/search',
                         dataType: 'json',


### PR DESCRIPTION
Fix that user cannot search another user with two characters when configuring followers.

