### PR TITLE
Add subregion concept to cluster mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ subprojects {
     mockito_version = "2.23.4"
     handlebars_version = "4.0.5"
     jackson_version = "2.11.2"
+    lombok_version = "1.18.20"
     groovy_version = project.property("groovy.version")
     junit_version = project.property("junit.version")
   }

--- a/ngrinder-controller/build.gradle
+++ b/ngrinder-controller/build.gradle
@@ -70,16 +70,14 @@ dependencies {
     compile (group: "org.codehaus.groovy", name: "groovy-jsr223", version: groovy_version)
     compile (group: "com.unboundid", name: "unboundid-ldapsdk", version: "5.1.1")
 
-    compileOnly (group: "org.projectlombok", name: "lombok", version: "1.18.8")
-    annotationProcessor (group: "org.projectlombok", name: "lombok", version: "1.18.8")
+    compileOnly (group: "org.projectlombok", name: "lombok", version: lombok_version)
+    annotationProcessor (group: "org.projectlombok", name: "lombok", version: lombok_version)
 
     providedRuntime (group: "org.springframework.boot", name: "spring-boot-starter-tomcat", version: spring_boot_version)
 
     testCompile (group: "junit", name: "junit", version: junit_version)
     testCompile (group: "org.easytesting", name: "fest-assert", version: "1.4")
     testCompile (group: "org.springframework.boot", name: "spring-boot-starter-test", version: spring_boot_version)
-    testCompileOnly (group: "org.projectlombok", name: "lombok", version: "1.18.8")
-    testAnnotationProcessor (group: "org.projectlombok", name: "lombok", version: "1.18.8")
 }
 
 

--- a/ngrinder-controller/src/main/java/org/ngrinder/agent/controller/AgentManagerApiController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/agent/controller/AgentManagerApiController.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang.StringUtils;
 import org.ngrinder.agent.service.AgentService;
 import org.ngrinder.agent.service.AgentPackageService;
+import org.ngrinder.common.exception.NGrinderRuntimeException;
 import org.ngrinder.infra.config.Config;
 import org.ngrinder.model.AgentInfo;
 import org.ngrinder.model.User;
@@ -33,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang.StringUtils.*;
 import static org.ngrinder.common.util.CollectionUtils.*;
 import static org.ngrinder.common.util.SpringSecurityUtils.containsAuthority;
 import static org.ngrinder.common.util.SpringSecurityUtils.getCurrentAuthorities;
@@ -57,19 +59,23 @@ public class AgentManagerApiController {
 
 	@GetMapping("/regions")
 	@PreAuthorize("hasAnyRole('A', 'S', 'U')")
-	public List<String> getAvailableRegions(final User user) {
+	public List<Map<String, Object>> getAvailableRegions(final User user) {
 		return regionService.getAllVisibleRegionNames();
 	}
 
 	@GetMapping("/download_link")
 	@PreAuthorize("hasAnyRole('A', 'S', 'U')")
-	public String getDownloadLink(final User user,  @RequestParam(value = "region", required = false) final String region) {
+	public String getDownloadLink(final User user,
+								  @RequestParam(defaultValue = "") final String region,
+								  @RequestParam(defaultValue = "") final String subregion) {
 		String downloadLink = "";
-		File agentPackage = null;
+		File agentPackage;
 		if (config.isClustered()) {
 			if (StringUtils.isNotBlank(region)) {
-				final RegionInfo regionInfo = regionService.getOne(region);
-				agentPackage = agentPackageService.createAgentPackage(region, regionInfo.getIp(), regionInfo.getControllerPort(), null);
+				final RegionInfo regionInfo = regionService.getOne(region, subregion);
+				agentPackage = agentPackageService.createAgentPackage(defaultIfEmpty(subregion, region), regionInfo.getIp(), regionInfo.getPort(), null);
+			} else {
+				throw new NGrinderRuntimeException("Region is not exist.\nthe region must exist in cluster mode.");
 			}
 		} else {
 			agentPackage = agentPackageService.createAgentPackage("", "", config.getControllerPort(), null);
@@ -85,40 +91,59 @@ public class AgentManagerApiController {
 	 */
 	@GetMapping({"", "/", "/list"})
 	@PreAuthorize("hasAnyRole('A', 'S', 'U')")
-	public List<AgentInfo> getAll(final User user, @RequestParam(value = "region", required = false) final String region) {
+	public List<AgentInfo> getAll(final User user,
+								  @RequestParam(defaultValue = "") final String region,
+								  @RequestParam(defaultValue = "") final String subregion) {
 		final Collection<? extends GrantedAuthority> authorities = getCurrentAuthorities();
 		return agentService.getAllActive()
 			.stream()
-			.filter(agent -> filterAgentByCluster(region, agent.getRegion()))
-			.filter(agent -> filterAgentByUserAuthorityAndUserId(authorities, user.getUserId(), region, agent.getRegion()))
+			.filter(agent -> filterAgentByCluster(region, subregion, agent))
+			.filter(agent -> filterAgentByUserAuthorityAndUserId(authorities, user.getUserId(),
+				region, subregion, agent))
 			.collect(toList());
 	}
 
 	/**
 	 * Filter agent list by referring to cluster
 	 */
-	private boolean filterAgentByCluster(String region, String agentRegion) {
-		//noinspection SimplifiableIfStatement
-		if (StringUtils.isEmpty(region)) {
+	private boolean filterAgentByCluster(String region, String subregion, AgentInfo agentInfo) {
+		if (isEmpty(region)) {
 			return true;
-		} else {
-			return agentRegion.startsWith(region + "_owned") || region.equals(agentRegion);
 		}
+
+		String agentRegion = agentInfo.getRegion();
+		if (!region.equals(agentRegion)) {
+			return false;
+		}
+
+		String agentSubregion = agentInfo.getSubregion();
+		if (isEmpty(subregion)) {
+			return isEmpty(agentSubregion);
+		}
+
+		return agentSubregion.startsWith(subregion + "_owned") || agentSubregion.equals(subregion);
 	}
 
 	/**
 	 * Filter agent list using user authority and user id
 	 */
-	private boolean filterAgentByUserAuthorityAndUserId(Collection<? extends GrantedAuthority> authorities, String userId, String region, String agentRegion) {
+	private boolean filterAgentByUserAuthorityAndUserId(Collection<? extends GrantedAuthority> authorities,
+														String userId, String region, String subregion, AgentInfo agentInfo) {
 		if (isAdminOrSuperUser(authorities)) {
 			return true;
 		}
 
-		if (StringUtils.isEmpty(region)) {
+		String agentRegion = agentInfo.getRegion();
+		if (isEmpty(region)) {
 			return !agentRegion.contains("_owned_") || agentRegion.endsWith("_owned_" + userId);
-		} else {
+		}
+
+		if (isEmpty(subregion)) {
 			return agentRegion.startsWith(region + "_owned_" + userId) || region.equals(agentRegion);
 		}
+
+		String agentSubregion = agentInfo.getSubregion();
+		return agentSubregion.startsWith(subregion + "_owned_" + userId) || agentSubregion.equals(subregion);
 	}
 
 	/**

--- a/ngrinder-controller/src/main/java/org/ngrinder/agent/controller/AgentManagerApiController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/agent/controller/AgentManagerApiController.java
@@ -192,17 +192,6 @@ public class AgentManagerApiController {
 	}
 
 	/**
-	 * Get all agents from database.
-	 *
-	 * @return agentInfoList
-	 */
-	@PreAuthorize("hasAnyRole('A')")
-	@GetMapping(value = {"/", ""})
-	public List<AgentInfo> getAll() {
-		return agentService.getAllActive();
-	}
-
-	/**
 	 * Get the agent for the given agent ip and name.
 	 *
 	 * @return agentInfo

--- a/ngrinder-controller/src/main/java/org/ngrinder/agent/controller/AgentManagerApiController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/agent/controller/AgentManagerApiController.java
@@ -156,9 +156,9 @@ public class AgentManagerApiController {
 	/**
 	 * Get the current performance of the given agent.
 	 *
-	 * @param ip agent ip
-	 * @param name agent name
-	 * @param region agent region
+	 * @param ip     agent ip
+	 * @param name   agent name
+	 * @param region agent main region(not subregion)
 	 *
 	 * @return json message
 	 */
@@ -298,7 +298,10 @@ public class AgentManagerApiController {
 	 */
 	@PostMapping("/connect/{ip}/{port}")
 	@PreAuthorize("permitAll")
-	public void addConnectionAgent(@PathVariable String ip, @PathVariable int port, @RequestParam String region) {
+	public void addConnectionAgent(@PathVariable String ip,
+								   @PathVariable int port,
+								   @RequestParam String region,
+								   @RequestParam String subregion) {
 		agentService.addConnectionAgent(ip, port, region);
 	}
 }

--- a/ngrinder-controller/src/main/java/org/ngrinder/agent/controller/AgentManagerApiController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/agent/controller/AgentManagerApiController.java
@@ -296,8 +296,10 @@ public class AgentManagerApiController {
 	 */
 	@GetMapping("/availableAgentCount")
 	@PreAuthorize("permitAll")
-	public Map<String, Integer> getAvailableAgentCount(User user, @RequestParam String targetRegion) {
-		return buildMap("availableAgentCount", agentService.getReadyAgentCount(user.getUserId(), targetRegion));
+	public Map<String, Integer> getAvailableAgentCount(User user,
+													   @RequestParam String targetRegion,
+													   @RequestParam(defaultValue = "") String targetSubregion) {
+		return buildMap("availableAgentCount", agentService.getReadyAgentCount(user.getUserId(), targetRegion, targetSubregion));
 	}
 
 	/**

--- a/ngrinder-controller/src/main/java/org/ngrinder/agent/controller/MonitorDownloadController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/agent/controller/MonitorDownloadController.java
@@ -13,6 +13,7 @@
  */
 package org.ngrinder.agent.controller;
 
+import org.ngrinder.agent.model.PackageDownloadInfo;
 import org.ngrinder.agent.service.AgentPackageService;
 import org.ngrinder.common.util.FileDownloadUtils;
 import org.ngrinder.infra.config.Config;
@@ -66,8 +67,8 @@ public class MonitorDownloadController {
 	@GetMapping("")
 	public String download(ModelMap model) {
 		try {
-			final File monitorPackage = agentPackageService.createPackage(monitorPackageHandler, "",
-				null, config.getMonitorPort(), "");
+			PackageDownloadInfo packageDownloadInfo = PackageDownloadInfo.builder().connectionPort(config.getMonitorPort()).build();
+			final File monitorPackage = agentPackageService.createPackage(monitorPackageHandler, packageDownloadInfo);
 			model.clear();
 			return "redirect:/monitor/download/" + monitorPackage.getName();
 		} catch (Exception e) {

--- a/ngrinder-controller/src/main/java/org/ngrinder/agent/model/Connection.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/agent/model/Connection.java
@@ -6,7 +6,6 @@ import org.ngrinder.model.BaseEntity;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 
-@SuppressWarnings("JpaDataSourceORMInspection")
 @Getter
 @Setter
 @ToString

--- a/ngrinder-controller/src/main/java/org/ngrinder/agent/model/PackageDownloadInfo.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/agent/model/PackageDownloadInfo.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2012-present NAVER Corp.
+ *
+ * This file is part of The nGrinder software distribution. Refer to
+ * the file LICENSE which is part of The nGrinder distribution for
+ * licensing details. The nGrinder distribution is available on the
+ * Internet at https://naver.github.io/ngrinder
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ngrinder.agent.model;
+
+import lombok.*;
+import org.apache.commons.lang.StringUtils;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@AllArgsConstructor
+public class PackageDownloadInfo {
+	private String connectionIp;
+	private String region;
+	private String subregion;
+	private String owner;
+	private int connectionPort;
+
+	public PackageDownloadInfo() {
+		connectionIp = "";
+		region = "";
+		subregion = "";
+		owner = "";
+	}
+
+	public String getFullRegion() {
+		String fullRegion = region;
+		return StringUtils.isEmpty(subregion) ? fullRegion : fullRegion + "." + subregion;
+	}
+}

--- a/ngrinder-controller/src/main/java/org/ngrinder/common/constant/CacheConstants.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/common/constant/CacheConstants.java
@@ -33,6 +33,8 @@ public interface CacheConstants {
 	String LOCAL_CACHE_CURRENT_PERFTEST_STATISTICS = "current_perftest_statistics";
 
 	String REGION_ATTR_KEY = "region";
+	String SUBREGION_ATTR_KEY = "subregion";
+
 	String REGION_EXECUTOR_SERVICE_NAME = "region_executor";
 	String AGENT_EXECUTOR_SERVICE_NAME = "agent_executor";
 

--- a/ngrinder-controller/src/main/java/org/ngrinder/common/constant/ClusterConstants.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/common/constant/ClusterConstants.java
@@ -24,6 +24,7 @@ public interface ClusterConstants {
 	String PROP_CLUSTER_MEMBERS = "cluster.members";
 	String PROP_CLUSTER_PORT = "cluster.port";
 	String PROP_CLUSTER_REGION = "cluster.region";
+	String PROP_CLUSTER_SUBREGION = "cluster.subregion";
 	String PROP_CLUSTER_HOST = "cluster.host";
 	String PROP_CLUSTER_MODE = "cluster.mode";
 	String PROP_CLUSTER_SAFE_DIST = "cluster.safe_dist";

--- a/ngrinder-controller/src/main/java/org/ngrinder/common/util/RegionUtils.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/common/util/RegionUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2012-present NAVER Corp.
+ *
+ * This file is part of The nGrinder software distribution. Refer to
+ * the file LICENSE which is part of The nGrinder distribution for
+ * licensing details. The nGrinder distribution is available on the
+ * Internet at https://naver.github.io/ngrinder
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ngrinder.common.util;
+
+import lombok.NoArgsConstructor;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptySet;
+import static lombok.AccessLevel.PRIVATE;
+import static org.apache.commons.lang.StringUtils.isEmpty;
+
+@NoArgsConstructor(access = PRIVATE)
+public final class RegionUtils {
+
+	/**
+	 * Convert configured string type of subregion value to {@link Set}.
+	 *
+	 * @param subregionsString value of 'ngrinder.cluster.subregion' in system-ex.conf, it concatenates with ',' like sub1,sub2
+	 */
+	public static Set<String> convertSubregionsStringToSet(String subregionsString) {
+		return isEmpty(subregionsString) ? emptySet() : new HashSet<>(asList(subregionsString.split(",")));
+	}
+
+}

--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/config/Config.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/config/Config.java
@@ -48,15 +48,20 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Date;
+import java.util.Map;
 import java.util.Properties;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static net.grinder.util.NoOp.noOp;
 import static org.apache.commons.io.FileUtils.*;
+import static org.apache.commons.lang.StringUtils.defaultIfEmpty;
 import static org.apache.commons.lang.StringUtils.isEmpty;
+import static org.ngrinder.common.constant.CacheConstants.REGION_ATTR_KEY;
+import static org.ngrinder.common.constant.CacheConstants.SUBREGION_ATTR_KEY;
 import static org.ngrinder.common.constant.DatabaseConstants.PROP_DATABASE_UNIT_TEST;
 import static org.ngrinder.common.constants.GrinderConstants.GRINDER_SECURITY_LEVEL_NORMAL;
 import static org.ngrinder.common.model.Home.PATH_SCRIPT_TEMPLATE_DIRECTORY;
+import static org.ngrinder.common.util.CollectionUtils.newHashMap;
 import static org.ngrinder.common.util.FileUtils.copyResourceToFile;
 import static org.ngrinder.common.util.PathUtils.getSubPath;
 import static org.ngrinder.common.util.Preconditions.checkNotNull;
@@ -205,6 +210,22 @@ public class Config extends AbstractConfig implements ControllerConstants, Clust
 	 */
 	public String getRegion() {
 		return isClustered() ? getClusterProperties().getProperty(PROP_CLUSTER_REGION) : NONE_REGION;
+	}
+
+	/**
+	 * Get the current region and subregion from the configuration.
+	 *
+	 * @return region and subregion. If it's not clustered mode, return "NONE"
+	 */
+	public Map<String, String> getRegionWithSubregion() {
+		Map<String, String> region = newHashMap();
+		region.put(REGION_ATTR_KEY, getRegion());
+
+		if (isClustered()) {
+			region.put(SUBREGION_ATTR_KEY, defaultIfEmpty(getClusterProperties().getProperty(PROP_CLUSTER_SUBREGION), ""));
+		}
+
+		return region;
 	}
 
 	/**

--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/config/DynamicCacheConfig.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/config/DynamicCacheConfig.java
@@ -146,9 +146,10 @@ public class DynamicCacheConfig implements ClusterConstants {
 		return topicConfig;
 	}
 
+	@SuppressWarnings("CollectionAddAllCanBeReplacedWithConstructor")
 	private Map<String, String> getClusterMemberAttributes() {
 		Map<String, String> attributes = new HashMap<>();
-		attributes.put(REGION_ATTR_KEY, config.getRegion());
+		attributes.putAll(config.getRegionWithSubregion());
 		return attributes;
 	}
 

--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/hazelcast/task/RegionInfoTask.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/hazelcast/task/RegionInfoTask.java
@@ -6,10 +6,15 @@ import org.ngrinder.region.model.RegionInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.Serializable;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 import static net.grinder.util.NetworkUtils.DEFAULT_LOCAL_HOST_ADDRESS;
 import static org.apache.commons.lang.StringUtils.defaultIfBlank;
+import static org.ngrinder.common.constant.CacheConstants.REGION_ATTR_KEY;
+import static org.ngrinder.common.constant.CacheConstants.SUBREGION_ATTR_KEY;
+import static org.ngrinder.common.util.RegionUtils.convertSubregionsStringToSet;
 
 /**
  * Task for getting region info from clustered controller.
@@ -24,6 +29,8 @@ public class RegionInfoTask implements Callable<RegionInfo>, Serializable {
 
 	public RegionInfo call() {
 		final String regionIP = defaultIfBlank(config.getCurrentIP(), DEFAULT_LOCAL_HOST_ADDRESS);
-		return new RegionInfo(config.getRegion(), regionIP, config.getControllerPort());
+		Map<String, String> regionWithSubregion = config.getRegionWithSubregion();
+		Set<String> subregion = convertSubregionsStringToSet(regionWithSubregion.get(SUBREGION_ATTR_KEY));
+		return new RegionInfo(regionWithSubregion.get(REGION_ATTR_KEY), subregion, regionIP, config.getControllerPort());
 	}
 }

--- a/ngrinder-controller/src/main/java/org/ngrinder/packages/AgentPackageHandler.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/packages/AgentPackageHandler.java
@@ -1,7 +1,7 @@
 package org.ngrinder.packages;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang.StringUtils;
+import org.ngrinder.agent.model.PackageDownloadInfo;
 import org.ngrinder.infra.schedule.ScheduledTaskService;
 import org.springframework.stereotype.Component;
 
@@ -54,21 +54,12 @@ public class AgentPackageHandler extends PackageHandler {
 	}
 
 	@Override
-	public Map<String, Object> getConfigParam(String regionName, String controllerIP, int port, String owner) {
+	public Map<String, Object> getConfigParam(PackageDownloadInfo packageDownloadInfo) {
 		Map<String, Object> confMap = newHashMap();
-		confMap.put("controllerIP", controllerIP);
-		confMap.put("controllerPort", String.valueOf(port));
-		if (StringUtils.isEmpty(regionName)) {
-			regionName = "NONE";
-		}
-		if (StringUtils.isNotBlank(owner)) {
-			if (StringUtils.isEmpty(regionName)) {
-				regionName = "owned_" + owner;
-			} else {
-				regionName = regionName + "_owned_" + owner;
-			}
-		}
-		confMap.put("controllerRegion", regionName);
+		confMap.put("controllerIP", packageDownloadInfo.getConnectionIp());
+		confMap.put("controllerPort", String.valueOf(packageDownloadInfo.getConnectionPort()));
+		confMap.put("subregion", packageDownloadInfo.getSubregion());
+		confMap.put("owner", packageDownloadInfo.getOwner());
 		return confMap;
 	}
 

--- a/ngrinder-controller/src/main/java/org/ngrinder/packages/MonitorPackageHandler.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/packages/MonitorPackageHandler.java
@@ -1,5 +1,6 @@
 package org.ngrinder.packages;
 
+import org.ngrinder.agent.model.PackageDownloadInfo;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
@@ -11,8 +12,8 @@ import static org.ngrinder.common.util.CollectionUtils.buildMap;
 public class MonitorPackageHandler extends PackageHandler {
 
 	@Override
-	public Map<String, Object> getConfigParam(String regionName, String controllerIP, int port, String owner) {
-		return buildMap("monitorPort", String.valueOf(port));
+	public Map<String, Object> getConfigParam(PackageDownloadInfo packageDownloadInfo) {
+		return buildMap("monitorPort", String.valueOf(packageDownloadInfo.getConnectionPort()));
 	}
 
 	@Override

--- a/ngrinder-controller/src/main/java/org/ngrinder/packages/PackageHandler.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/packages/PackageHandler.java
@@ -9,6 +9,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
+import org.ngrinder.agent.model.PackageDownloadInfo;
 import org.ngrinder.agent.service.AgentPackageService;
 import org.ngrinder.infra.config.Config;
 import org.slf4j.Logger;
@@ -88,12 +89,12 @@ public abstract class PackageHandler {
 			bytes.length, TarArchiveEntry.DEFAULT_FILE_MODE);
 	}
 
-	public File getPackageFile(String regionName, String connectionIP, String ownerName, boolean forWindow) {
+	public File getPackageFile(PackageDownloadInfo packageDownloadInfo, boolean forWindow) {
 		File packageDir = getPackageDir();
 		if (packageDir.mkdirs()) {
 			LOGGER.info("{} is created", packageDir.getPath());
 		}
-		final String packageName = getDistributionPackageName(regionName, connectionIP, ownerName, forWindow);
+		final String packageName = getDistributionPackageName(packageDownloadInfo, forWindow);
 		return new File(packageDir, packageName);
 	}
 
@@ -122,15 +123,13 @@ public abstract class PackageHandler {
 	/**
 	 * Get distributable package name with appropriate extension.
 	 *
-	 * @param regionName   region   namee
-	 * @param connectionIP where it will connect to
-	 * @param ownerName    owner name
-	 * @param forWindow    if true, then package type is zip,if false, package type is tar.
+	 * @param packageDownloadInfo  information for downloading package
+	 * @param forWindow            if true, then package type is zip,if false, package type is tar.
 	 * @return String  module full name.
 	 */
-	private String getDistributionPackageName(String regionName, String connectionIP, String ownerName, boolean forWindow) {
-		return getPackageName() + getFilenamePostFix(regionName) + getFilenamePostFix(connectionIP) +
-			getFilenamePostFix(ownerName) + (forWindow ? ".zip" : ".tar");
+	private String getDistributionPackageName(PackageDownloadInfo packageDownloadInfo, boolean forWindow) {
+		return getPackageName() + getFilenamePostFix(packageDownloadInfo.getFullRegion()) + getFilenamePostFix(packageDownloadInfo.getConnectionIp()) +
+			getFilenamePostFix(packageDownloadInfo.getOwner()) + (forWindow ? ".zip" : ".tar");
 	}
 
 	private String getFilenamePostFix(String value) {
@@ -169,7 +168,7 @@ public abstract class PackageHandler {
 		return this.getModuleName() + "-" + config.getVersion();
 	}
 
-	public abstract Map<String, Object> getConfigParam(String regionName, String controllerIP, int port, String owner);
+	public abstract Map<String, Object> getConfigParam(PackageDownloadInfo packageDownloadInfo);
 
 	public abstract Set<String> getPackageDependentLibs();
 

--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/repository/PerfTestRepository.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/repository/PerfTestRepository.java
@@ -60,7 +60,7 @@ public interface PerfTestRepository extends JpaRepository<PerfTest, Long>, JpaSp
 	 * @param region region where the test belong to
 	 * @return perf test list
 	 */
-	List<PerfTest> findAllByStatusAndRegionOrderByScheduledTimeAsc(Status status, String region);
+	List<PerfTest> findAllByStatusAndRegionStartsWithOrderByScheduledTimeAsc(Status status, String region);
 
 	/**
 	 * Find all {@link PerfTest}s created between the given start and end date and having the the given region.

--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/repository/PerfTestSpecification.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/repository/PerfTestSpecification.java
@@ -81,6 +81,10 @@ public abstract class PerfTestSpecification {
 		return (Specification<PerfTest>) (root, query, cb) -> cb.or(cb.equal(root.get("region"), region), cb.equal(root.get("region"), ""));
 	}
 
+	public static Specification<PerfTest> regionStartsWith(final String region) {
+		return (Specification<PerfTest>) (root, query, cb) -> cb.like(root.get("region"), region + "%");
+	}
+
 	/**
 	 * Get the {@link Specification} whichs provide empty predicate.
 	 *

--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/AgentManager.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/AgentManager.java
@@ -29,7 +29,6 @@ import net.grinder.engine.controller.AgentControllerIdentityImplementation;
 import net.grinder.message.console.AgentControllerState;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.StringUtils;
 import org.ngrinder.agent.service.AgentPackageService;
 import org.ngrinder.agent.store.AgentInfoStore;
 import org.ngrinder.common.constant.ControllerConstants;
@@ -100,7 +99,7 @@ public class AgentManager implements ControllerConstants, AgentDownloadRequestLi
 			File logFile = null;
 			try {
 				logFile = new File(config.getHome().getPerfTestLogDirectory(testId.replace("test_", "")),
-						agentIdentity.getName() + "-" + agentIdentity.getRegion() + "-log.zip");
+						agentIdentity.getName() + "-" + agentIdentity.getSubregion() + "-log.zip");
 				FileUtils.writeByteArrayToFile(logFile, logs);
 			} catch (IOException e) {
 				LOGGER.error("Error while write logs from {} to {}", agentAddress.getIdentity().getName(),
@@ -222,18 +221,6 @@ public class AgentManager implements ControllerConstants, AgentDownloadRequestLi
 		return (AgentControllerIdentityImplementation) identity;
 	}
 
-	public String extractRegionKey(String agentRegion) {
-		if (agentRegion != null && agentRegion.contains("_owned_")) {
-			return agentRegion.substring(0, agentRegion.indexOf("_owned_"));
-		}
-		if (agentRegion != null && agentRegion.contains("owned_")) {
-			return agentRegion.substring(0, agentRegion.indexOf("owned_"));
-		}
-		if (StringUtils.isEmpty(agentRegion)) {
-			return Config.NONE_REGION;
-		}
-		return agentRegion;
-	}
 
 	/**
 	 * Get the current system performance of the given agent.

--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/ClusteredPerfTestService.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/ClusteredPerfTestService.java
@@ -48,7 +48,7 @@ public class ClusteredPerfTestService extends PerfTestService {
 	@Override
 	@Transactional
 	public PerfTest getNextRunnablePerfTestPerfTestCandidate() {
-		List<PerfTest> readyPerfTests = getPerfTestRepository().findAllByStatusAndRegionOrderByScheduledTimeAsc(
+		List<PerfTest> readyPerfTests = getPerfTestRepository().findAllByStatusAndRegionStartsWithOrderByScheduledTimeAsc(
 				Status.READY, getConfig().getRegion());
 		List<PerfTest> filteredPerfTests = filterCurrentlyRunningTestUsersTest(readyPerfTests);
 		return filteredPerfTests.isEmpty() ? null : filteredPerfTests.get(0);

--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/PerfTestRunnable.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/PerfTestRunnable.java
@@ -188,7 +188,7 @@ public class PerfTestRunnable implements ControllerConstants {
 	 * @return true if enough agents
 	 */
 	protected boolean hasEnoughFreeAgents(PerfTest test) {
-		int size = agentService.getAllAttachedFreeApprovedAgentsForUser(test.getCreatedBy().getUserId()).size();
+		int size = agentService.getAllAttachedFreeApprovedAgentsForUser(test.getCreatedBy().getUserId(), test.getRegion()).size();
 		if (test.getAgentCount() != null && test.getAgentCount() > size) {
 			perfTestService.markProgress(test, "The test is tried to execute but there is not enough free agents."
 					+ "\n- Current free agent count : " + size + "  / Requested : " + test.getAgentCount() + "\n");

--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/PerfTestService.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/PerfTestService.java
@@ -245,11 +245,13 @@ public class PerfTestService extends AbstractPerfTestService implements Controll
 		if (user != null) {
 			spec = spec.and(createdBy(user));
 		}
-		if (config.isClustered()) {
-			spec = spec.and(idRegionEqual(region));
-		}
+
 		if (statuses.length != 0) {
 			spec = spec.and(statusSetEqual(statuses));
+		}
+
+		if (config.isClustered()) {
+			spec = spec.and(regionStartsWith(region));
 		}
 
 		return perfTestRepository.findAll(spec);

--- a/ngrinder-controller/src/main/java/org/ngrinder/region/model/RegionInfo.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/region/model/RegionInfo.java
@@ -17,6 +17,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.io.Serializable;
+import java.util.Set;
 
 /**
  * Region info to be shared b/w controllers.
@@ -29,9 +30,11 @@ public class RegionInfo implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
-	private final Integer controllerPort;
+	private final Integer port;
 
 	private String regionName;
+
+	private Set<String> subregion;
 
 	@Setter
 	private String ip;
@@ -42,11 +45,11 @@ public class RegionInfo implements Serializable {
 	/**
 	 * Constructor with true visibility.
 	 *
-	 * @param ip              ip
-	 * @param controllerPort  controllerPort
+	 * @param ip    ip
+	 * @param port  port
 	 */
-	public RegionInfo(String ip, int controllerPort) {
-		this(ip, controllerPort, true);
+	public RegionInfo(String ip, int port) {
+		this(ip, port, true);
 	}
 
 	/**
@@ -63,19 +66,26 @@ public class RegionInfo implements Serializable {
 	 * Constructor.
 	 *
 	 * @param ip              ip
-	 * @param controllerPort  controllerPort
+	 * @param port  	      port
 	 * @param visible         true if visible
 	 */
-	public RegionInfo(String ip, Integer controllerPort, boolean visible) {
+	public RegionInfo(String ip, Integer port, boolean visible) {
 		this.ip = ip;
-		this.controllerPort = controllerPort;
+		this.port = port;
 		this.visible = visible;
 	}
 
-	public RegionInfo(String regionName , String ip, Integer controllerPort) {
-		this.ip = ip;
-		this.controllerPort = controllerPort;
+	public RegionInfo(String regionName, String ip, Integer port) {
 		this.regionName = regionName;
+		this.ip = ip;
+		this.port = port;
+	}
+
+	public RegionInfo(String regionName, Set<String> subregion , String ip, Integer port) {
+		this.regionName = regionName;
+		this.subregion = subregion;
+		this.ip = ip;
+		this.port = port;
 	}
 
 }

--- a/ngrinder-controller/src/main/java/org/ngrinder/region/service/RegionService.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/region/service/RegionService.java
@@ -34,6 +34,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.ngrinder.common.constant.CacheConstants.*;
@@ -66,7 +67,7 @@ public class RegionService {
 				}
 			} else {
 				final String regionIP = StringUtils.defaultIfBlank(config.getCurrentIP(), NetworkUtils.DEFAULT_LOCAL_HOST_ADDRESS);
-				regions.put(config.getRegion(), new RegionInfo(config.getRegion(), regionIP, config.getControllerPort()));
+				regions.put(config.getRegion(), new RegionInfo(config.getRegion(), emptySet(), regionIP, config.getControllerPort()));
 			}
 			return regions;
 		}

--- a/ngrinder-controller/src/main/java/org/ngrinder/region/service/RegionService.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/region/service/RegionService.java
@@ -27,16 +27,18 @@ import org.ngrinder.infra.config.Config;
 import org.ngrinder.infra.hazelcast.HazelcastService;
 import org.ngrinder.infra.hazelcast.task.RegionInfoTask;
 import org.ngrinder.region.model.RegionInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.ngrinder.common.constant.CacheConstants.*;
 import static org.ngrinder.common.util.ExceptionUtils.processException;
+import static org.ngrinder.common.util.RegionUtils.convertSubregionsStringToSet;
 
 /**
  * Region service class. This class responsible to keep the status of available regions.
@@ -46,9 +48,6 @@ import static org.ngrinder.common.util.ExceptionUtils.processException;
 @Service
 @RequiredArgsConstructor
 public class RegionService {
-
-	@SuppressWarnings("UnusedDeclaration")
-	private static final Logger LOGGER = LoggerFactory.getLogger(RegionService.class);
 
 	private final Config config;
 
@@ -73,16 +72,21 @@ public class RegionService {
 		}
 	}, REGION_CACHE_TIME_TO_LIVE_SECONDS, TimeUnit.SECONDS);
 
-	private final Supplier<List<String>> allRegionNames = Suppliers.memoizeWithExpiration(new Supplier<List<String>>() {
+	private final Supplier<List<Map<String, String>>> allRegionNames = Suppliers.memoizeWithExpiration(new Supplier<List<Map<String, String>>>() {
 		@Override
-		public List<String> get() {
+		public List<Map<String, String>> get() {
 			Set<Member> members = hazelcastInstance.getCluster().getMembers();
-			List<String> regionNames = new ArrayList<>();
+			List<Map<String, String>> regionNames = new ArrayList<>();
+
 			for (Member member : members) {
 				if (member.getAttributes().containsKey(REGION_ATTR_KEY)) {
-					regionNames.add(member.getAttributes().get(REGION_ATTR_KEY));
+					Map<String, String> regionMap = new HashMap<>();
+					regionMap.put(REGION_ATTR_KEY, member.getAttributes().get(REGION_ATTR_KEY));
+					regionMap.put(SUBREGION_ATTR_KEY, member.getAttributes().get(SUBREGION_ATTR_KEY));
+					regionNames.add(regionMap);
 				}
 			}
+
 			return regionNames;
 		}
 	}, REGION_CACHE_TIME_TO_LIVE_SECONDS, TimeUnit.SECONDS);
@@ -131,7 +135,21 @@ public class RegionService {
 		if (regionInfo != null) {
 			return regionInfo;
 		}
-		throw new NGrinderRuntimeException(regionName + "is not exist");
+		throw new NGrinderRuntimeException(regionName + " is not exist");
+	}
+
+	public RegionInfo getOne(String region, String subregion) {
+		if (isEmpty(subregion)) {
+			return getOne(region);
+		}
+
+		RegionInfo regionInfo = getAll().get(region);
+		if (regionInfo != null) {
+			if (isEmpty(subregion) || regionInfo.getSubregion().contains(subregion)) {
+				return regionInfo;
+			}
+		}
+		throw new NGrinderRuntimeException(region + "." + subregion + " is not exist");
 	}
 
 	/**
@@ -143,11 +161,17 @@ public class RegionService {
 		return allRegions.get();
 	}
 
-	public List<String> getAllVisibleRegionNames() {
+	public List<Map<String, Object>> getAllVisibleRegionNames() {
 		if (config.isClustered()) {
-			return allRegionNames.get();
+			return allRegionNames.get().stream().map(region -> {
+					Map<String, Object> regionInfo = new HashMap<>();
+					String subregionAttributes = region.get(SUBREGION_ATTR_KEY);
+					regionInfo.put(REGION_ATTR_KEY, region.get(REGION_ATTR_KEY));
+					regionInfo.put(SUBREGION_ATTR_KEY, convertSubregionsStringToSet(subregionAttributes));
+					return regionInfo;
+			}).collect(toList());
 		} else {
-			return Collections.emptyList();
+			return emptyList();
 		}
 	}
 

--- a/ngrinder-controller/src/main/java/org/ngrinder/starter/NGrinderControllerStarter.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/starter/NGrinderControllerStarter.java
@@ -82,6 +82,9 @@ public class NGrinderControllerStarter extends SpringBootServletInitializer {
 				description = "This cluster member's region name")
 			private String region = null;
 
+			@Parameter(names = {"-sr", "--subregion"},
+				description = "This cluster member's subregion names with ',' concatenated format like sub1,sub2")
+			private String subregion = "";
 
 			@Parameter(names = {"-dh", "--database-host"},
 				description = "database host. The default value is localhost")
@@ -104,6 +107,7 @@ public class NGrinderControllerStarter extends SpringBootServletInitializer {
 					System.setProperty("cluster.host", clusterHost);
 				}
 				System.setProperty("cluster.region", region);
+				System.setProperty("cluster.subregion", subregion);
 				System.setProperty("controller.controller_port", controllerPort.toString());
 				System.setProperty("database.type", databaseType);
 				if ("h2".equals(databaseType)) {

--- a/ngrinder-controller/src/main/resources/cluster-properties.map
+++ b/ngrinder-controller/src/main/resources/cluster-properties.map
@@ -2,6 +2,7 @@ cluster.enabled,false,ngrinder.cluster.mode
 cluster.members,,ngrinder.cluster.uris
 cluster.port,40003,ngrinder.cluster.listener.port
 cluster.region,NONE,ngrinder.cluster.region
+cluster.subregion,,ngrinder.cluster.subregion
 cluster.hidden_region,false,ngrinder.cluster.region.hide
 cluster.safe_dist,false,
 cluster.mode,,

--- a/ngrinder-controller/src/main/resources/messages_cn.properties
+++ b/ngrinder-controller/src/main/resources/messages_cn.properties
@@ -422,6 +422,7 @@ agent.list.port=\u7AEF\u53E3
 agent.list.name=\u540D\u79F0
 agent.list.state=\u72B6\u6001
 agent.list.region=\u533A\u57DF
+agent.list.owner=Owner
 agent.list.approved=\u5DF2\u8BB8\u53EF
 agent.list.disapproved=\u672A\u8BB8\u53EF
 agent.list.IP=IP

--- a/ngrinder-controller/src/main/resources/messages_en.properties
+++ b/ngrinder-controller/src/main/resources/messages_en.properties
@@ -427,6 +427,7 @@ agent.list.port=Port
 agent.list.name=Name
 agent.list.state=State
 agent.list.region=Region
+agent.list.owner=Owner
 agent.list.approved=Approved
 agent.list.disapproved=Disapproved
 agent.list.IP=IP

--- a/ngrinder-controller/src/main/resources/messages_kr.properties
+++ b/ngrinder-controller/src/main/resources/messages_kr.properties
@@ -416,6 +416,7 @@ agent.list.port=\uD3EC\uD2B8
 agent.list.name=\uC5D0\uC774\uC804\uD2B8\uBA85
 agent.list.state=\uC0C1\uD0DC
 agent.list.region=\uC9C0\uC5ED
+agent.list.owner=소유자
 agent.list.approved=\uC2B9\uC778\uB428
 agent.list.disapproved=\uC2B9\uC778\uC548\uB428
 agent.list.IP=IP

--- a/ngrinder-controller/src/main/resources/ngrinder_agent_home_template/agent_agent.conf
+++ b/ngrinder-controller/src/main/resources/ngrinder_agent_home_template/agent_agent.conf
@@ -1,7 +1,8 @@
 common.start_mode=agent
 agent.controller_host=${controllerIP}
 agent.controller_port=${controllerPort}
-agent.region=${controllerRegion}
+agent.subregion=${subregion}
+agent.owner=${owner}
 #agent.host_id=
 #agent.server_mode=true
 

--- a/ngrinder-controller/src/test/java/org/ngrinder/agent/controller/AgentManagerApiControllerTest.java
+++ b/ngrinder-controller/src/test/java/org/ngrinder/agent/controller/AgentManagerApiControllerTest.java
@@ -72,7 +72,7 @@ public class AgentManagerApiControllerTest extends AbstractNGrinderTransactional
 	@SuppressWarnings("unchecked")
 	@Test
 	public void testGetAgentList() {
-		agentApiController.getAll(userContext.getCurrentUser(), "NONE");
+		agentApiController.getAll(userContext.getCurrentUser(), "NONE", "");
 
 		// create a temp download dir and file for this function
 		File directory = config.getHome().getDownloadDirectory();
@@ -92,7 +92,7 @@ public class AgentManagerApiControllerTest extends AbstractNGrinderTransactional
 			e.printStackTrace();
 		}
 
-		agentApiController.getAll(userContext.getCurrentUser(), "NONE");
+		agentApiController.getAll(userContext.getCurrentUser(), "NONE", "");
 	}
 
 	@Test

--- a/ngrinder-controller/src/test/java/org/ngrinder/agent/controller/AgentManagerApiControllerTest.java
+++ b/ngrinder-controller/src/test/java/org/ngrinder/agent/controller/AgentManagerApiControllerTest.java
@@ -69,7 +69,6 @@ public class AgentManagerApiControllerTest extends AbstractNGrinderTransactional
 		RequestContextHolder.resetRequestAttributes();
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testGetAgentList() {
 		agentApiController.getAll(userContext.getCurrentUser(), "NONE", "");
@@ -135,7 +134,7 @@ public class AgentManagerApiControllerTest extends AbstractNGrinderTransactional
 	@Test
 	public void testGetAvailableAgentCount() {
 		String targetRegion = "test";
-		Map<String, Integer> response = agentApiController.getAvailableAgentCount(getTestUser(), targetRegion);
+		Map<String, Integer> response = agentApiController.getAvailableAgentCount(getTestUser(), targetRegion, "");
 		assertThat(0, is(response.get("availableAgentCount")));
 	}
 }

--- a/ngrinder-controller/src/test/java/org/ngrinder/agent/service/AgentCountMapTest.java
+++ b/ngrinder-controller/src/test/java/org/ngrinder/agent/service/AgentCountMapTest.java
@@ -55,8 +55,14 @@ public class AgentCountMapTest extends AbstractNGrinderTransactionalTest {
 	private AgentInfo createAgentInfo(String region, String subregion, boolean approved, AgentControllerState status) {
 		AgentInfo agentInfo = createAgentInfo(region, approved, status);
 		AgentControllerIdentityImplementation agentIdentity = new AgentControllerIdentityImplementation("", "");
-		agentIdentity.setRegion(subregion);
+		agentIdentity.setSubregion(subregion);
 		agentInfo.setAgentIdentity(agentIdentity);
+		return agentInfo;
+	}
+
+	private AgentInfo createAgentInfo(String region, String subregion, boolean approved, AgentControllerState status, String owner) {
+		AgentInfo agentInfo = createAgentInfo(region, subregion, approved, status);
+		((AgentControllerIdentityImplementation) agentInfo.getAgentIdentity()).setOwner(owner);
 		return agentInfo;
 	}
 
@@ -68,20 +74,24 @@ public class AgentCountMapTest extends AbstractNGrinderTransactionalTest {
 		List<AgentInfo> agents = asList(
 			createAgentInfo("hello", true, READY),
 			createAgentInfo("hello", true, READY),
-			createAgentInfo("hello_owned_wow", true, READY),
+			createAgentInfo("hello", "", true, READY, "wow"),
+
 			createAgentInfo("haha", true, READY),
 			createAgentInfo("haha", true, READY),
 			createAgentInfo("haha", true, READY),
 			createAgentInfo("haha", "sub1",true, READY),
 			createAgentInfo("haha", "sub2", true, READY),
 			createAgentInfo("haha", false, READY),
-			createAgentInfo("haha_owned_my", true, READY),
-			createAgentInfo("haha", "sub1_owned_my",true, READY),
-			createAgentInfo("woowo_owned_my", true, READY),
+			createAgentInfo("haha", "", true, READY, "my"),
+			createAgentInfo("haha", "sub1",true, READY, "my"),
+
+			createAgentInfo("woowo", "", true, READY, "my"),
+
 			createAgentInfo("wowo", true, READY),
 			createAgentInfo("wowo", true, READY),
 			createAgentInfo("wowo", true, READY),
 			createAgentInfo("wowo", false, READY),
+
 			createAgentInfo("kiki", false, READY)
 		);
 
@@ -91,8 +101,8 @@ public class AgentCountMapTest extends AbstractNGrinderTransactionalTest {
 		subregions.add("sub2");
 
 		regionMap.put("hello", new RegionInfo("hello", subregions, null, null));
-		regionMap.put("haha", new RegionInfo("hello", subregions, null, null));
-		regionMap.put("wowo", new RegionInfo("hello", subregions, null, null));
+		regionMap.put("haha", new RegionInfo("haha", subregions, null, null));
+		regionMap.put("wowo", new RegionInfo("wowo", subregions, null, null));
 
 		when(mockAgentInfoStore.getAllAgentInfo()).thenReturn(agents);
 		when(mockRegionService.getAll()).thenReturn(regionMap);

--- a/ngrinder-controller/src/test/java/org/ngrinder/agent/service/AgentServiceTest.java
+++ b/ngrinder-controller/src/test/java/org/ngrinder/agent/service/AgentServiceTest.java
@@ -1,5 +1,7 @@
 package org.ngrinder.agent.service;
 
+import net.grinder.engine.controller.AgentControllerIdentityImplementation;
+import org.apache.commons.lang.StringUtils;
 import org.junit.Test;
 import org.ngrinder.AbstractNGrinderTransactionalTest;
 import org.ngrinder.infra.hazelcast.HazelcastService;
@@ -30,8 +32,8 @@ public class AgentServiceTest extends AbstractNGrinderTransactionalTest {
 	/**
 	 *
 	 * Priority of agent selection.
-	 * 1. owned agent of recently used.
-	 * 2. owned agent.
+	 * 1. dedicated agent of recently used.
+	 * 2. dedicated agent.
 	 * 3. public agent of recently used.
 	 * 4. public agent.
 	 *
@@ -49,41 +51,39 @@ public class AgentServiceTest extends AbstractNGrinderTransactionalTest {
 
 		assertThat(selectedAgents.size(), is(5));
 
-		List<AgentInfo> selectedOwnedAgents = selectedAgents
+		List<AgentInfo> selectedDedicatedAgents = selectedAgents
 			.stream()
-			.filter(agentInfo -> agentInfo.getRegion().contains("owned"))
+			.filter(agentInfo -> StringUtils.isNotEmpty(agentInfo.getOwner()))
 			.collect(toList());
-
-		assertThat(selectedOwnedAgents.size(), is(2));
+		assertThat(selectedDedicatedAgents.size(), is(2));
 
 		// Check if recently used agents are selected.
-		assertTrue(selectedAgents.contains(createAgentInfo("test-agent-1", "test-region")));
-		assertTrue(selectedAgents.contains(createAgentInfo("test-agent-3", "test-region")));
-		assertTrue(selectedAgents.contains(createAgentInfo("test-agent-5", "test-region")));
+		assertTrue(selectedAgents.contains(createAgentInfo("test-agent-1")));
+		assertTrue(selectedAgents.contains(createAgentInfo("test-agent-3")));
+		assertTrue(selectedAgents.contains(createAgentInfo("test-agent-5")));
 
 		// Add recently used agents.
-
-		recentlyUsedAgents.add(createAgentInfo("test-agent-11", "test-region_owned_test-user"));
-		recentlyUsedAgents.add(createAgentInfo("test-agent-14", "test-region_owned_test-user"));
+		recentlyUsedAgents.add(createAgentInfo("test-agent-11", "test-region", TEST_USER_ID));
+		recentlyUsedAgents.add(createAgentInfo("test-agent-14", "test-region", TEST_USER_ID));
 		hazelcastService.put(DIST_MAP_NAME_RECENTLY_USED_AGENTS, TEST_USER_ID, recentlyUsedAgents);
 
 		// Add owned agents for another test.
-		allFreeAgents.add(createAgentInfo("test-agent-8", "test-region_owned_test-user"));
-		allFreeAgents.add(createAgentInfo("test-agent-9", "test-region_owned_test-user"));
-		allFreeAgents.add(createAgentInfo("test-agent-10", "test-region_owned_test-user"));
-		allFreeAgents.add(createAgentInfo("test-agent-11", "test-region_owned_test-user"));
-		allFreeAgents.add(createAgentInfo("test-agent-12", "test-region_owned_test-user"));
-		allFreeAgents.add(createAgentInfo("test-agent-13", "test-region_owned_test-user"));
-		allFreeAgents.add(createAgentInfo("test-agent-14", "test-region_owned_test-user"));
-		allFreeAgents.add(createAgentInfo("test-agent-15", "test-region_owned_test-user"));
+		allFreeAgents.add(createAgentInfo("test-agent-8", "test-region", "another-user"));
+		allFreeAgents.add(createAgentInfo("test-agent-9", "test-region", "another-user"));
+		allFreeAgents.add(createAgentInfo("test-agent-10", "test-region", "another-user"));
+		allFreeAgents.add(createAgentInfo("test-agent-11", "test-region", TEST_USER_ID));
+		allFreeAgents.add(createAgentInfo("test-agent-12", "test-region", TEST_USER_ID));
+		allFreeAgents.add(createAgentInfo("test-agent-13", "test-region", TEST_USER_ID));
+		allFreeAgents.add(createAgentInfo("test-agent-14", "test-region", TEST_USER_ID));
+		allFreeAgents.add(createAgentInfo("test-agent-15", "test-region", TEST_USER_ID));
 
 		selectedAgents = agentService.selectAgent(testUser, allFreeAgents, 3);
 
 		assertThat(selectedAgents.size(), is(3));
 		// Check if recently used owned agents are selected.
-		assertTrue(selectedAgents.contains(createAgentInfo("test-agent-6", "test-region_owned_test-user")));
-		assertTrue(selectedAgents.contains(createAgentInfo("test-agent-11", "test-region_owned_test-user")));
-		assertTrue(selectedAgents.contains(createAgentInfo("test-agent-14", "test-region_owned_test-user")));
+		assertTrue(selectedAgents.contains(createAgentInfo("test-agent-6")));
+		assertTrue(selectedAgents.contains(createAgentInfo("test-agent-11")));
+		assertTrue(selectedAgents.contains(createAgentInfo("test-agent-14")));
 
 		hazelcastService.delete(DIST_MAP_NAME_RECENTLY_USED_AGENTS, TEST_USER_ID);
 	}
@@ -93,7 +93,7 @@ public class AgentServiceTest extends AbstractNGrinderTransactionalTest {
 		cachedAgents.add(createAgentInfo("test-agent-1", "test-region"));
 		cachedAgents.add(createAgentInfo("test-agent-3", "test-region"));
 		cachedAgents.add(createAgentInfo("test-agent-5", "test-region"));
-		cachedAgents.add(createAgentInfo("test-agent-6", "test-region_owned_test-user"));
+		cachedAgents.add(createAgentInfo("test-agent-6", "test-region", TEST_USER_ID));
 		return cachedAgents;
 	}
 
@@ -107,9 +107,19 @@ public class AgentServiceTest extends AbstractNGrinderTransactionalTest {
 		allFreeAgents.add(createAgentInfo("test-agent-5", "test-region"));
 
 		// owned agents
-		allFreeAgents.add(createAgentInfo("test-agent-6", "test-region_owned_test-user"));
-		allFreeAgents.add(createAgentInfo("test-agent-7", "test-region_owned_test-user"));
+		allFreeAgents.add(createAgentInfo("test-agent-6", "test-region", TEST_USER_ID));
+		allFreeAgents.add(createAgentInfo("test-agent-7", "test-region", TEST_USER_ID));
+		allFreeAgents.add(createAgentInfo("test-agent-8", "test-region", "another-user"));
+		allFreeAgents.add(createAgentInfo("test-agent-9", "test-region", "another-user"));
+		allFreeAgents.add(createAgentInfo("test-agent-10", "test-region", "another-user"));
 		return allFreeAgents;
+	}
+
+	private AgentInfo createAgentInfo(String name) {
+		AgentInfo agentInfo = new AgentInfo();
+		agentInfo.setIp("1.1.1.1");
+		agentInfo.setName(name);
+		return agentInfo;
 	}
 
 	private AgentInfo createAgentInfo(String name, String region) {
@@ -117,6 +127,14 @@ public class AgentServiceTest extends AbstractNGrinderTransactionalTest {
 		agentInfo.setIp("1.1.1.1");
 		agentInfo.setName(name);
 		agentInfo.setRegion(region);
+		return agentInfo;
+	}
+
+	private AgentInfo createAgentInfo(String name, String region, String owner) {
+		AgentInfo agentInfo = createAgentInfo(name, region);
+		AgentControllerIdentityImplementation identityImplementation = new AgentControllerIdentityImplementation("", "");
+		identityImplementation.setOwner(owner);
+		agentInfo.setAgentIdentity(identityImplementation);
 		return agentInfo;
 	}
 }

--- a/ngrinder-controller/src/test/java/org/ngrinder/agent/service/MockAgentService.java
+++ b/ngrinder-controller/src/test/java/org/ngrinder/agent/service/MockAgentService.java
@@ -41,7 +41,7 @@ public class MockAgentService extends AgentService {
 	 */
 	public synchronized void runAgent(User user, final SingleConsole singleConsole,
 									  final GrinderProperties grinderProperties, final Integer agentCount) {
-		final Set<AgentInfo> allFreeAgents = getAllAttachedFreeApprovedAgentsForUser(user.getUserId());
+		final Set<AgentInfo> allFreeAgents = getAllAttachedFreeApprovedAgentsForUser(user.getUserId(), "");
 		final Set<AgentInfo> necessaryAgents = selectAgent(user, allFreeAgents, agentCount);
 
 		hazelcastService.put(DIST_MAP_NAME_RECENTLY_USED_AGENTS, user.getUserId(), necessaryAgents);

--- a/ngrinder-controller/src/test/java/org/ngrinder/perftest/service/PerfTestRunnableTest.java
+++ b/ngrinder-controller/src/test/java/org/ngrinder/perftest/service/PerfTestRunnableTest.java
@@ -100,7 +100,7 @@ public class PerfTestRunnableTest extends AbstractAgentReadyTest implements Cont
 		List<AgentIdentity> agentIdentities = new ArrayList<>(agentManager.getAllAttachedAgents());
 		for (AgentIdentity agentIdentity : agentIdentities) {
 			AgentControllerIdentityImplementation identity = cast(agentIdentity);
-			identity.setRegion("");
+			identity.setSubregion("");
 			AgentInfo agentInfo = new AgentInfo();
 			agentInfo.setIp(identity.getIp());
 			agentInfo.setPort(0);

--- a/ngrinder-controller/src/test/java/org/ngrinder/perftest/service/PerfTestRunnableTest.java
+++ b/ngrinder-controller/src/test/java/org/ngrinder/perftest/service/PerfTestRunnableTest.java
@@ -100,12 +100,14 @@ public class PerfTestRunnableTest extends AbstractAgentReadyTest implements Cont
 		List<AgentIdentity> agentIdentities = new ArrayList<>(agentManager.getAllAttachedAgents());
 		for (AgentIdentity agentIdentity : agentIdentities) {
 			AgentControllerIdentityImplementation identity = cast(agentIdentity);
+			identity.setRegion("");
 			AgentInfo agentInfo = new AgentInfo();
 			agentInfo.setIp(identity.getIp());
 			agentInfo.setPort(0);
 			agentInfo.setName(identity.getName());
 			agentInfo.setApproved(true);
 			agentInfo.setState(READY);
+			agentInfo.setAgentIdentity(identity);
 			agentInfoStore.updateAgentInfo(agentInfo.getAgentKey(), agentInfo);
 		}
 

--- a/ngrinder-controller/src/test/java/org/ngrinder/region/service/RegionServiceTest.java
+++ b/ngrinder-controller/src/test/java/org/ngrinder/region/service/RegionServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
+import static org.ngrinder.common.constant.CacheConstants.REGION_ATTR_KEY;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 public class RegionServiceTest extends AbstractNGrinderTransactionalTest {
@@ -41,6 +42,9 @@ public class RegionServiceTest extends AbstractNGrinderTransactionalTest {
 		String currentRegion = config.getRegion();
 
 		assertThat(regionService.getAll().keySet().contains(currentRegion)).isEqualTo(true);
-		assertThat(regionService.getAllVisibleRegionNames().contains(currentRegion)).isEqualTo(true);
+		assertThat(regionService.getAllVisibleRegionNames()
+			.stream()
+			.anyMatch(regionNamesMap -> regionNamesMap.get(REGION_ATTR_KEY).equals(currentRegion)))
+			.isEqualTo(true);
 	}
 }

--- a/ngrinder-core/src/main/java/net/grinder/AgentController.java
+++ b/ngrinder-core/src/main/java/net/grinder/AgentController.java
@@ -412,7 +412,8 @@ public class AgentController implements Agent, AgentConstants {
 			};
 
 			if (agentConfig.isConnectionMode()) {
-				m_sender.send(new ConnectionAgentMessage(m_agentIdentity.getIp(), agentConfig.getAgentHostID(), agentConfig.getConnectionAgentPort()));
+				m_sender.send(new ConnectionAgentMessage(m_agentIdentity.getIp(),agentConfig.getAgentHostID(),
+					agentConfig.getRegion(), agentConfig.getConnectionAgentPort()));
 			}
 		}
 

--- a/ngrinder-core/src/main/java/net/grinder/console/communication/AgentProcessControlImplementation.java
+++ b/ngrinder-core/src/main/java/net/grinder/console/communication/AgentProcessControlImplementation.java
@@ -131,7 +131,7 @@ public class AgentProcessControlImplementation implements AgentProcessControl {
 		messageDispatchRegistry.set(ConnectionAgentMessage.class, new AbstractHandler<ConnectionAgentMessage>() {
 			public void handle(final ConnectionAgentMessage message) {
 				m_connectionAgentListener.apply(listener -> {
-					listener.onConnectionAgentMessage(message.getIp(), message.getName(), message.getPort());
+					listener.onConnectionAgentMessage(message.getIp(), message.getName(), message.getRegion(), message.getPort());
 				});
 			}
 		});

--- a/ngrinder-core/src/main/java/net/grinder/console/communication/AgentProcessControlImplementation.java
+++ b/ngrinder-core/src/main/java/net/grinder/console/communication/AgentProcessControlImplementation.java
@@ -131,7 +131,7 @@ public class AgentProcessControlImplementation implements AgentProcessControl {
 		messageDispatchRegistry.set(ConnectionAgentMessage.class, new AbstractHandler<ConnectionAgentMessage>() {
 			public void handle(final ConnectionAgentMessage message) {
 				m_connectionAgentListener.apply(listener -> {
-					listener.onConnectionAgentMessage(message.getIp(), message.getName(), message.getRegion(), message.getPort());
+					listener.onConnectionAgentMessage(message.getIp(), message.getName(), message.getSubregion(), message.getPort());
 				});
 			}
 		});

--- a/ngrinder-core/src/main/java/net/grinder/console/communication/ConnectionAgentListener.java
+++ b/ngrinder-core/src/main/java/net/grinder/console/communication/ConnectionAgentListener.java
@@ -3,5 +3,5 @@ package net.grinder.console.communication;
 import java.util.EventListener;
 
 public interface ConnectionAgentListener extends EventListener {
-	void onConnectionAgentMessage(String ip, String name, int port);
+	void onConnectionAgentMessage(String ip, String name, String region, int port);
 }

--- a/ngrinder-core/src/main/java/net/grinder/engine/communication/ConnectionAgentMessage.java
+++ b/ngrinder-core/src/main/java/net/grinder/engine/communication/ConnectionAgentMessage.java
@@ -5,14 +5,14 @@ import net.grinder.communication.Message;
 public class ConnectionAgentMessage implements Message {
 	private final String ip;
 	private final String name;
-	private final String region;
+	private final String subregion;
 	private final int port;
 
-	public ConnectionAgentMessage(String ip, String name, String region, int port) {
+	public ConnectionAgentMessage(String ip, String name, String subregion, int port) {
 		this.ip = ip;
 		this.name = name;
 		this.port = port;
-		this.region = region;
+		this.subregion = subregion;
 	}
 
 	public String getIp() {
@@ -23,8 +23,8 @@ public class ConnectionAgentMessage implements Message {
 		return name;
 	}
 
-	public String getRegion() {
-		return region;
+	public String getSubregion() {
+		return subregion;
 	}
 
 	public int getPort() {

--- a/ngrinder-core/src/main/java/net/grinder/engine/communication/ConnectionAgentMessage.java
+++ b/ngrinder-core/src/main/java/net/grinder/engine/communication/ConnectionAgentMessage.java
@@ -5,12 +5,14 @@ import net.grinder.communication.Message;
 public class ConnectionAgentMessage implements Message {
 	private final String ip;
 	private final String name;
+	private final String region;
 	private final int port;
 
-	public ConnectionAgentMessage(String ip, String name, int port) {
+	public ConnectionAgentMessage(String ip, String name, String region, int port) {
 		this.ip = ip;
 		this.name = name;
 		this.port = port;
+		this.region = region;
 	}
 
 	public String getIp() {
@@ -19,6 +21,10 @@ public class ConnectionAgentMessage implements Message {
 
 	public String getName() {
 		return name;
+	}
+
+	public String getRegion() {
+		return region;
 	}
 
 	public int getPort() {

--- a/ngrinder-core/src/main/java/net/grinder/engine/controller/AgentControllerIdentityImplementation.java
+++ b/ngrinder-core/src/main/java/net/grinder/engine/controller/AgentControllerIdentityImplementation.java
@@ -30,7 +30,9 @@ public class AgentControllerIdentityImplementation extends AbstractAgentControll
 
 	private final String ip;
 
-	private String region;
+	private String subregion;
+
+	private String owner;
 
 	/**
 	 * Constructor.
@@ -61,6 +63,14 @@ public class AgentControllerIdentityImplementation extends AbstractAgentControll
 		m_number = number;
 	}
 
+	public String getOwner() {
+		return owner;
+	}
+
+	public void setOwner(String owner) {
+		this.owner = owner;
+	}
+
 	/**
 	 * Get ip.
 	 * 
@@ -70,12 +80,12 @@ public class AgentControllerIdentityImplementation extends AbstractAgentControll
 		return ip;
 	}
 
-	public String getRegion() {
-		return region;
+	public String getSubregion() {
+		return subregion;
 	}
 
-	public void setRegion(String region) {
-		this.region = region;
+	public void setSubregion(String subregion) {
+		this.subregion = subregion;
 	}
 
 }

--- a/ngrinder-core/src/main/java/org/ngrinder/NGrinderAgentStarterParam.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/NGrinderAgentStarterParam.java
@@ -58,13 +58,14 @@ public class NGrinderAgentStarterParam {
 			@Parameter(names = {"-cp", "--controller-port"}, description = "controller port.")
 			public Integer controllerPort = null;
 
-			@Parameter(names = {"-r", "--region"}, description = "region")
-			public String region = null;
+			@Parameter(names = {"-sb", "--subregion"}, description = "subregion")
+			public String subregion = null;
 
+			@Parameter(names = {"-onr", "--owner"}, description = "owner")
+			public String owner = null;
 
 			@Parameter(names = {"-hi", "--host-id"}, description = "this agent's unique host id")
 			public String hostId = null;
-
 
 			@Override
 			protected void processInternal() {
@@ -80,8 +81,12 @@ public class NGrinderAgentStarterParam {
 					System.setProperty(PROP_AGENT_HOST_ID, hostId);
 				}
 
-				if (region != null) {
-					System.setProperty(PROP_AGENT_REGION, region);
+				if (subregion != null) {
+					System.setProperty(PROP_AGENT_SUBREGION, subregion);
+				}
+
+				if (owner != null) {
+					System.setProperty(PROP_AGENT_OWNER, owner);
 				}
 			}
 		},

--- a/ngrinder-core/src/main/java/org/ngrinder/common/constants/AgentConstants.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/common/constants/AgentConstants.java
@@ -28,7 +28,8 @@ public interface AgentConstants {
 	String PROP_AGENT_JAVA_OPT = "agent.java_opt";
 	String PROP_AGENT_JVM_CLASSPATH = "agent.jvm.classpath";
 	String PROP_AGENT_LIMIT_XMX = "agent.limit_xmx";
-	String PROP_AGENT_REGION = "agent.region";
+	String PROP_AGENT_SUBREGION = "agent.subregion";
+	String PROP_AGENT_OWNER = "agent.owner";
 	String PROP_AGENT_SERVER_MODE = "agent.server_mode";
 	String PROP_AGENT_CONNECTION_MODE = "agent.connection_mode";
 	String PROP_AGENT_CONNECTION_PORT = "agent.connection_port";
@@ -38,4 +39,7 @@ public interface AgentConstants {
 
 	String VALUE_AGENT_TO_CONTROLLER = "agent_to_controller";
 	String VALUE_CONTROLLER_TO_AGENT = "controller_to_agent";
+
+	// Deprecated, agent region is automatically set to the controller region which the agent is connected.
+	String PROP_AGENT_REGION = "agent.region";
 }

--- a/ngrinder-core/src/main/java/org/ngrinder/infra/AgentConfig.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/infra/AgentConfig.java
@@ -341,7 +341,15 @@ public class AgentConfig implements AgentConstants, MonitorConstants, CommonCons
 	}
 
 	public String getRegion() {
-		return getAgentProperties().getProperty(PROP_AGENT_REGION);
+		return defaultIfEmpty(getAgentProperties().getProperty(PROP_AGENT_REGION), "");
+	}
+
+	public String getSubregion() {
+		return defaultIfEmpty(getAgentProperties().getProperty(PROP_AGENT_SUBREGION), "");
+	}
+
+	public String getOwner() {
+		return defaultIfEmpty(getAgentProperties().getProperty(PROP_AGENT_OWNER), "");
 	}
 
 	public String getAgentHostID() {

--- a/ngrinder-core/src/main/java/org/ngrinder/model/AgentInfo.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/model/AgentInfo.java
@@ -121,16 +121,22 @@ public class AgentInfo extends BaseEntity<AgentInfo> {
 
 	public String getSubregion() {
 		if (agentIdentity instanceof AgentControllerIdentityImplementation) {
-			String configuredRegion = defaultIfEmpty(((AgentControllerIdentityImplementation) agentIdentity).getRegion(), "");
-			return StringUtils.equals(configuredRegion, region) ? "" : configuredRegion;
+			return defaultIfEmpty(((AgentControllerIdentityImplementation) agentIdentity).getSubregion(), "");
 		}
 		return "";
 	}
 
 	public void setSubregion(String subregion) {
 		if (agentIdentity instanceof AgentControllerIdentityImplementation) {
-			((AgentControllerIdentityImplementation) agentIdentity).setRegion(subregion);
+			((AgentControllerIdentityImplementation) agentIdentity).setSubregion(subregion);
 		}
+	}
+
+	public String getOwner() {
+		if (agentIdentity instanceof AgentControllerIdentityImplementation) {
+			return defaultIfEmpty(((AgentControllerIdentityImplementation) agentIdentity).getOwner(), "");
+		}
+		return "";
 	}
 
 	@JsonIgnore

--- a/ngrinder-core/src/main/java/org/ngrinder/model/AgentInfo.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/model/AgentInfo.java
@@ -18,6 +18,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import net.grinder.common.processidentity.AgentIdentity;
+import net.grinder.engine.controller.AgentControllerIdentityImplementation;
 import net.grinder.message.console.AgentControllerState;
 import org.apache.commons.lang.StringUtils;
 import org.hibernate.annotations.Type;
@@ -25,6 +26,7 @@ import org.hibernate.annotations.Type;
 import javax.persistence.*;
 
 import static java.util.Objects.hash;
+import static org.apache.commons.lang.StringUtils.defaultIfEmpty;
 import static org.ngrinder.common.util.AccessUtils.getSafe;
 
 /**
@@ -115,6 +117,20 @@ public class AgentInfo extends BaseEntity<AgentInfo> {
 
 	public boolean isApproved() {
 		return approved != null && approved;
+	}
+
+	public String getSubregion() {
+		if (agentIdentity instanceof AgentControllerIdentityImplementation) {
+			String configuredRegion = defaultIfEmpty(((AgentControllerIdentityImplementation) agentIdentity).getRegion(), "");
+			return StringUtils.equals(configuredRegion, region) ? "" : configuredRegion;
+		}
+		return "";
+	}
+
+	public void setSubregion(String subregion) {
+		if (agentIdentity instanceof AgentControllerIdentityImplementation) {
+			((AgentControllerIdentityImplementation) agentIdentity).setRegion(subregion);
+		}
 	}
 
 	@JsonIgnore

--- a/ngrinder-core/src/main/java/org/ngrinder/service/IAgentManagerService.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/service/IAgentManagerService.java
@@ -110,12 +110,25 @@ public interface IAgentManagerService {
 	void stop(String ip, String name) throws IOException;
 
 	/**
-	 * Get Ready agent state count return
+	 * Ready status agent count return
 	 *
-	 * @param userId current user id
-	 * @return int readyAgentCnt
+	 * @param userId          the login user id
+	 * @param targetRegion    the name of target region
+	 *
+	 * @return ready status agent count
 	 */
 	int getReadyAgentCount(String userId, String targetRegion);
+
+	/**
+	 * Ready status agent count return
+	 *
+	 * @param userId          the login user id
+	 * @param targetRegion    the name of target region
+	 * @param targetSubregion the name of target subregion
+	 *
+	 * @return ready status agent count
+	 */
+	int getReadyAgentCount(String userId, String targetRegion, String targetSubregion);
 
 	@Deprecated
 	int getReadyAgentCount(User user, String targetRegion);

--- a/ngrinder-core/src/main/resources/agent-properties.map
+++ b/ngrinder-core/src/main/resources/agent-properties.map
@@ -2,6 +2,8 @@ agent.verbose,,verbose
 agent.controller_host,,agent.controller.ip,agent.console.ip,agent.controller_ip
 agent.controller_port,16001,agent.controller.port,agent.console.port
 agent.region,,
+agent.subregion,,
+agent.owner,,
 agent.host_id,,agent.hostid
 agent.server_mode,,
 agent.connection_mode,agent_to_controller,

--- a/ngrinder-core/src/main/resources/agent.conf
+++ b/ngrinder-core/src/main/resources/agent.conf
@@ -1,7 +1,8 @@
 common.start_mode=agent
 #agent.controller_host=
 #agent.controller_port=
-#agent.region=
+#agent.subregion=
+#agent.owner=
 #agent.host_id=
 #agent.server_mode=true
 #agent.connection_mode=true

--- a/ngrinder-frontend/src/js/components/Base.vue
+++ b/ngrinder-frontend/src/js/components/Base.vue
@@ -155,6 +155,11 @@
                         color: @error-color;
                     }
                 }
+
+                [data-toggle="dropdown"] {
+                    border-color: @error-color;
+                    color: @error-color;
+                }
             }
         }
 

--- a/ngrinder-frontend/src/js/components/agent/List.vue
+++ b/ngrinder-frontend/src/js/components/agent/List.vue
@@ -111,6 +111,10 @@
                 <div class="ellipsis region" :title="i18n(getRegion(props.rowData))" v-text="i18n(getRegion(props.rowData))"></div>
             </template>
 
+            <template slot="owner" slot-scope="props">
+                <div class="ellipsis owner" :title="props.rowData.owner" v-text="props.rowData.owner"></div>
+            </template>
+
             <template slot="approved" slot-scope="props">
                 <div class="btn-group">
                     <button class="btn btn-primary disapproved"
@@ -298,7 +302,6 @@
             }
             return region;
         }
-
 
         appendAgentKey(agents) {
             return agents.map(agent => {

--- a/ngrinder-frontend/src/js/components/agent/List.vue
+++ b/ngrinder-frontend/src/js/components/agent/List.vue
@@ -4,18 +4,35 @@
         <fieldSet>
             <legend class="header border-bottom d-flex">
                 <span v-text="i18n('agent.list.title')"></span>
-                <select v-if="ngrinder.config.clustered"
-                        class="form-control change-region ml-auto mt-auto mb-auto"
-                        v-model="selectedRegion" @change="changeRegion">
-                    <option value="">All</option>
-                    <optgroup v-for="regionInfo in regions" :label="regionInfo.region">
-                        <option :value="regionInfo.region" v-text="i18n(regionInfo.region)"></option>
-                        <option v-for="subregion in regionInfo.subregion"
-                                v-text="i18n(subregion)"
-                                :value="`${regionInfo.region}.${subregion}`">
-                        </option>
-                    </optgroup>
-                </select>
+
+                <ul class="dropdown ml-auto mb-2">
+                    <li>
+                        <button class="btn btn-default dropdown-toggle"
+                                data-toggle="dropdown" v-text="selectedRegion">
+                        </button>
+                        <ul class="dropdown-menu region-menu">
+                            <li @click.prevent="changeDropdown('')"><a class="dropdown-item">All</a></li>
+                            <li v-for="regionInfo in regions"
+                                :set="hasSubregions = hasSubregion(regionInfo)"
+                                :class="{ 'dropdown-submenu': hasSubregion(regionInfo) }">
+                                <a class="dropdown-item"
+                                   :class="{ 'dropdown-toggle': hasSubregions }"
+                                   @click="changeDropdown(regionInfo.region)">
+                                    <span v-text="regionInfo.region"></span>
+                                </a>
+                                <ul v-if="hasSubregions" class="dropdown-menu">
+                                    <li>
+                                        <a v-for="subregion in regionInfo.subregion"
+                                           class="dropdown-item"
+                                           @click.prevent="changeDropdown(`${regionInfo.region}.${subregion}`)"
+                                           v-text="i18n(subregion)">
+                                        </a>
+                                    </li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
             </legend>
         </fieldSet>
         <div class="card card-header search-bar border-bottom-0">
@@ -178,6 +195,7 @@
             if (this.subregion) {
                 this.selectedRegion += `.${this.subregion}`;
             }
+            this.updateRegion();
 
             this.queryFilter = this.createQueryFilter(this.query);
             this.$refs.searchInput.value = this.query; // Prevent to update query by periodic status update
@@ -293,6 +311,11 @@
             });
         }
 
+        changeDropdown(value) {
+            this.selectedRegion = value;
+            this.changeRegion();
+        }
+
         changeRegion() {
             this.$refs.vuetable.currentPage = 1;
             clearTimeout(this.updateStatesTimer);
@@ -305,6 +328,9 @@
             const regionTokens = this.selectedRegion.split(SUBREGION_SEPARATOR);
             this.region = regionTokens[0];
             this.subregion = regionTokens[1];
+            if (!this.selectedRegion) {
+                this.selectedRegion = 'All';
+            }
         }
 
         search() {
@@ -420,6 +446,10 @@
                 return { ip: ipAndName[0], name: ipAndName[1] };
             });
         }
+
+        hasSubregion(regionInfo) {
+            return regionInfo.subregion.length > 0;
+        }
     }
 </script>
 
@@ -435,10 +465,6 @@
         input[type='checkbox'] {
             vertical-align: bottom;
         }
-    }
-
-    .change-region {
-        width: 150px;
     }
 
     img.status {
@@ -479,6 +505,83 @@
 
         button {
             height: 32px;
+        }
+    }
+
+    .show {
+        button.dropdown-toggle {
+            border-bottom-right-radius: 0;
+            border-bottom-left-radius: 0;
+        }
+    }
+
+    .dropdown {
+        list-style: none;
+
+        button {
+            box-shadow: none;
+            text-align: left;
+            width: 150px;
+            border: 1px solid #ced4da
+        }
+
+        .region-menu {
+            width: 150px;
+            margin-top: 0;
+            border-top: none;
+            padding: 3px;
+
+            &.show {
+                border-top-right-radius: 0;
+                border-top-left-radius: 0;
+            }
+        }
+
+        .dropdown-item {
+            cursor: pointer;
+            font-size: 12px;
+            line-height: 20px;
+
+            &:hover {
+                color: #fff;
+                background-color: #007bff;
+            }
+        }
+
+        .dropdown-submenu {
+            position: relative;
+
+            > .dropdown-menu {
+                top: -6px;
+                padding: 3px;
+                margin-left: -2px;
+                left: -100%;
+                width: 100%;
+            }
+
+            &:hover {
+                > ul.dropdown-menu {
+                    display: block;
+                }
+            }
+        }
+
+        .dropdown-toggle::after {
+            display: inline-block;
+            position: absolute;
+            margin-left: 0.255em;
+            vertical-align: 0.255em;
+            content: "";
+            border-top: 0.3em solid;
+            border-right: 0.3em solid transparent;
+            border-bottom: 0;
+            border-left: 0.3em solid transparent;
+            right: 7px;
+            top: 10px;
+        }
+
+        button.dropdown-toggle::after {
+            top: 20px;
         }
     }
 

--- a/ngrinder-frontend/src/js/components/agent/List.vue
+++ b/ngrinder-frontend/src/js/components/agent/List.vue
@@ -8,28 +8,24 @@
                 <ul class="dropdown ml-auto mb-2">
                     <li>
                         <button class="btn btn-default dropdown-toggle"
-                                data-toggle="dropdown" v-text="selectedRegion">
+                                data-toggle="dropdown" v-text="i18n(selectedRegion)">
                         </button>
                         <ul class="dropdown-menu region-menu">
                             <li @click.prevent="changeDropdown('')"><a class="dropdown-item">All</a></li>
-                            <li v-for="regionInfo in regions"
-                                :set="hasSubregions = hasSubregion(regionInfo)"
-                                :class="{ 'dropdown-submenu': hasSubregion(regionInfo) }">
-                                <a class="dropdown-item"
-                                   :class="{ 'dropdown-toggle': hasSubregions }"
-                                   @click="changeDropdown(regionInfo.region)">
-                                    <span v-text="regionInfo.region"></span>
-                                </a>
-                                <ul v-if="hasSubregions" class="dropdown-menu">
-                                    <li>
-                                        <a v-for="subregion in regionInfo.subregion"
-                                           class="dropdown-item"
-                                           @click.prevent="changeDropdown(`${regionInfo.region}.${subregion}`)"
-                                           v-text="i18n(subregion)">
-                                        </a>
-                                    </li>
-                                </ul>
-                            </li>
+                            <template v-for="regionInfo in regions">
+                                <li class="dropdown-divider m-0"></li>
+                                <li>
+                                    <a class="dropdown-item"
+                                       @click.prevent="changeDropdown(regionInfo.region)"
+                                       v-text="i18n(regionInfo.region)">
+                                    </a>
+                                    <a v-for="subregion in regionInfo.subregion"
+                                       class="dropdown-item"
+                                       @click.prevent="changeDropdown(`${regionInfo.region}.${subregion}`)"
+                                       v-text="i18n(`${regionInfo.region}.${subregion}`)">
+                                    </a>
+                                </li>
+                            </template>
                         </ul>
                     </li>
                 </ul>
@@ -112,7 +108,7 @@
             </template>
 
             <template slot="region" slot-scope="props">
-                <div class="ellipsis region" :title="getRegion(props.rowData)" v-text="getRegion(props.rowData)"></div>
+                <div class="ellipsis region" :title="i18n(getRegion(props.rowData))" v-text="i18n(getRegion(props.rowData))"></div>
             </template>
 
             <template slot="approved" slot-scope="props">

--- a/ngrinder-frontend/src/js/components/agent/mixin/TableConfig.vue
+++ b/ngrinder-frontend/src/js/components/agent/mixin/TableConfig.vue
@@ -26,7 +26,7 @@
                     name: '__slot:name',
                     title: this.i18n('agent.list.name'),
                     sortField: 'name',
-                    width: '365px',
+                    width: '305px',
                 },
                 {
                     name: '__slot:version',
@@ -38,7 +38,13 @@
                     name: '__slot:region',
                     title: this.i18n('agent.list.region'),
                     sortField: 'region',
-                    width: '220px',
+                    width: '160px',
+                },
+                {
+                    name: '__slot:owner',
+                    title: this.i18n('agent.list.owner'),
+                    sortField: 'owner',
+                    width: '120px',
                 },
             ];
 

--- a/ngrinder-frontend/src/js/components/agent/modal/AddConnectionAgentModal.vue
+++ b/ngrinder-frontend/src/js/components/agent/modal/AddConnectionAgentModal.vue
@@ -14,11 +14,8 @@
                             <control-group :class="{ error: errors.has('region') }" v-show="ngrinder.config.clustered"
                                            name="region" labelMessageKey="agent.info.region">
                                 <select name="region" class="form-control"
-                                        v-model="region" v-validate="{ required: true }">
-                                    <option v-for="region in regions"
-                                            :value="region"
-                                            v-text="i18n(region)">
-                                    </option>
+                                        v-model="selectedRegion" v-validate="{ required: true }" @change="changeRegion">
+                                    <option v-for="regionInfo in regions" :value="regionInfo.region" v-text="i18n(regionInfo.region)"></option>
                                 </select>
                                 <div v-visible="errors.has('region')" class="validation-message" v-text="errors.first('region')"></div>
                             </control-group>
@@ -60,6 +57,8 @@
     import ModalBase from '../../common/modal/ModalBase.vue';
     import MessageMixin from '../../common/mixin/MessagesMixin.vue';
 
+    const SUBREGION_SEPARATOR = '.';
+
     @Component({
         name: 'addConnectionAgentModal',
         components: { ControlGroup },
@@ -71,7 +70,9 @@
         @Prop({ type: Array, required: false, default: [] })
         regions;
 
+        selectedRegion = '';
         region = '';
+        subregion = '';
 
         ip = '';
         port = null;
@@ -80,11 +81,17 @@
             this.$validator.validateAll()
                 .then(result => {
                     if (result) {
-                        this.$http.post(`/agent/api/connect/${this.ip}/${this.port}?region=${this.region}`)
+                        this.$http.post(`/agent/api/connect/${this.ip}/${this.port}?region=${this.region}&subregion=${this.subregion}`)
                             .catch(err => this.showErrorMsg(`Unable to connect to connection agent <b>${this.ip}:${this.port}</b><br>${err.response.data.message}`))
                             .finally(() => this.hide());
                     }
                 });
+        }
+
+        changeRegion() {
+            const regionTokens = this.selectedRegion.split(SUBREGION_SEPARATOR);
+            this.region = regionTokens[0];
+            this.subregion = regionTokens[1];
         }
 
         beforeShown() {

--- a/ngrinder-frontend/src/js/components/common/navigator/UserMenu.vue
+++ b/ngrinder-frontend/src/js/components/common/navigator/UserMenu.vue
@@ -21,17 +21,19 @@
                         <span v-text="i18n('navigator.dropDown.downloadAgent')"></span>
                     </a>
                     <ul class="dropdown-menu">
-                        <li class="dropdown-submenu" v-for="regionInfo in regions">
-                            <a class="dropdown-item dropdown-toggle" :href="`${contextPath}/agent/download?region=${regionInfo.region}`">
-                                <span v-text="i18n(regionInfo.region)"></span>
-                            </a>
-                            <ul v-if="regionInfo.subregion.length > 0" class="dropdown-menu">
-                                <li v-for="subregion in regionInfo.subregion">
-                                    <a class="dropdown-item" :href="`${contextPath}/agent/download?region=${regionInfo.region}&subregion=${subregion}`"
-                                       v-text="i18n(subregion)"></a>
-                                </li>
-                            </ul>
-                        </li>
+                        <template v-for="(regionInfo, idx) in regions">
+                            <li class="dropdown-submenu">
+                                <a class="dropdown-item"
+                                   :href="`${contextPath}/agent/download?region=${regionInfo.region}`"
+                                   v-text="i18n(regionInfo.region)">
+                                </a>
+                                <a v-for="subregion in regionInfo.subregion"
+                                   class="dropdown-item" :href="`${contextPath}/agent/download?region=${regionInfo.region}&subregion=${subregion}`"
+                                   v-text="i18n(`${regionInfo.region}.${subregion}`)">
+                                </a>
+                            </li>
+                            <li v-if="idx !== (regions.length -1)" class="dropdown-divider m-0"></li>
+                        </template>
                     </ul>
                 </li>
                 <li v-else>
@@ -44,16 +46,19 @@
                         <span v-text="i18n('navigator.dropDown.downloadPrivateAgent')"></span>
                     </a>
                     <ul class="dropdown-menu">
-                        <li class="dropdown-submenu" v-for="regionInfo in regions">
-                            <a class="dropdown-item" :href="`${contextPath}/agent/download/${regionInfo.region}/${ngrinder.currentUser.id}`"
-                               v-text="i18n(regionInfo.region)"></a>
-                            <ul class="dropdown-menu">
-                                <li v-for="subregion in regionInfo.subregion">
-                                    <a class="dropdown-item" :href="`${contextPath}/agent/download/${subregion}/${ngrinder.currentUser.id}`"
-                                       v-text="i18n(subregion)"></a>
-                                </li>
-                            </ul>
-                        </li>
+                        <template v-for="(regionInfo, idx) in regions">
+                            <li class="dropdown-submenu">
+                                <a class="dropdown-item"
+                                   :href="`${contextPath}/agent/download/${regionInfo.region}/${ngrinder.currentUser.id}`"
+                                   v-text="i18n(regionInfo.region)">
+                                </a>
+                                <a v-for="subregion in regionInfo.subregion"
+                                   class="dropdown-item" :href="`${contextPath}/agent/download/${regionInfo.region}/${subregion}/${ngrinder.currentUser.id}`"
+                                   v-text="i18n(`${regionInfo.region}.${subregion}`)">
+                                </a>
+                            </li>
+                            <li v-if="idx !== (regions.length -1)" class="dropdown-divider m-0"></li>
+                        </template>
                     </ul>
                 </li>
                 <li v-else>

--- a/ngrinder-frontend/src/js/components/common/navigator/UserMenu.vue
+++ b/ngrinder-frontend/src/js/components/common/navigator/UserMenu.vue
@@ -21,8 +21,15 @@
                         <span v-text="i18n('navigator.dropDown.downloadAgent')"></span>
                     </a>
                     <ul class="dropdown-menu">
-                        <li v-for="region in regions">
-                            <a class="dropdown-item" :href="`${contextPath}/agent/download?region=${region}`" v-text="i18n(region)"></a>
+                        <li class="dropdown-submenu" v-for="regionInfo in regions">
+                            <a class="dropdown-item" :href="`${contextPath}/agent/download?region=${regionInfo.region}`"
+                               v-text="i18n(regionInfo.region)"></a>
+                            <ul v-if="regionInfo.subregion.length > 0" class="dropdown-menu">
+                                <li v-for="subregion in regionInfo.subregion">
+                                    <a class="dropdown-item" :href="`${contextPath}/agent/download?region=${regionInfo.region}&subregion=${subregion}`"
+                                       v-text="i18n(subregion)"></a>
+                                </li>
+                            </ul>
                         </li>
                     </ul>
                 </li>
@@ -36,8 +43,15 @@
                         <span v-text="i18n('navigator.dropDown.downloadPrivateAgent')"></span>
                     </a>
                     <ul class="dropdown-menu">
-                        <li v-for="region in regions">
-                            <a class="dropdown-item" :href="`${contextPath}/agent/download/${region}/${ngrinder.currentUser.id}`" v-text="i18n(region)"></a>
+                        <li class="dropdown-submenu" v-for="regionInfo in regions">
+                            <a class="dropdown-item" :href="`${contextPath}/agent/download/${regionInfo.region}/${ngrinder.currentUser.id}`"
+                               v-text="i18n(regionInfo.region)"></a>
+                            <ul class="dropdown-menu">
+                                <li v-for="subregion in regionInfo.subregion">
+                                    <a class="dropdown-item" :href="`${contextPath}/agent/download/${subregion}/${ngrinder.currentUser.id}`"
+                                       v-text="i18n(subregion)"></a>
+                                </li>
+                            </ul>
                         </li>
                     </ul>
                 </li>

--- a/ngrinder-frontend/src/js/components/common/navigator/UserMenu.vue
+++ b/ngrinder-frontend/src/js/components/common/navigator/UserMenu.vue
@@ -17,13 +17,14 @@
             <li class="dropdown-divider"></li>
             <template v-if="isAdmin">
                 <li v-if="ngrinder.config.clustered" class="dropdown-submenu">
-                    <a class="dropdown-item">
+                    <a class="dropdown-item dropdown-toggle">
                         <span v-text="i18n('navigator.dropDown.downloadAgent')"></span>
                     </a>
                     <ul class="dropdown-menu">
                         <li class="dropdown-submenu" v-for="regionInfo in regions">
-                            <a class="dropdown-item" :href="`${contextPath}/agent/download?region=${regionInfo.region}`"
-                               v-text="i18n(regionInfo.region)"></a>
+                            <a class="dropdown-item dropdown-toggle" :href="`${contextPath}/agent/download?region=${regionInfo.region}`">
+                                <span v-text="i18n(regionInfo.region)"></span>
+                            </a>
                             <ul v-if="regionInfo.subregion.length > 0" class="dropdown-menu">
                                 <li v-for="subregion in regionInfo.subregion">
                                     <a class="dropdown-item" :href="`${contextPath}/agent/download?region=${regionInfo.region}&subregion=${subregion}`"
@@ -138,6 +139,20 @@
                     display: block;
                 }
             }
+        }
+
+        .dropdown-toggle::after {
+            display: inline-block;
+            position: absolute;
+            margin-left: 0.255em;
+            vertical-align: 0.255em;
+            content: "";
+            border-top: 0.3em solid;
+            border-right: 0.3em solid transparent;
+            border-bottom: 0;
+            border-left: 0.3em solid transparent;
+            right: 7px;
+            top: 10px;
         }
 
         .dropdown-submenu {

--- a/ngrinder-frontend/src/js/components/perftest/detail/Config.vue
+++ b/ngrinder-frontend/src/js/components/perftest/detail/Config.vue
@@ -26,27 +26,23 @@
                                         <li>
                                             <button class="btn btn-default dropdown-toggle"
                                                     :class="{ 'show-placeholder': isNoneRegion }"
-                                                    data-toggle="dropdown" v-text="selectedRegion">
+                                                    data-toggle="dropdown" v-text="i18n(selectedRegion)">
                                             </button>
                                             <ul class="dropdown-menu region-menu">
-                                                <li v-for="regionInfo in config.regions"
-                                                    :set="hasSubregions = hasSubregion(regionInfo)"
-                                                    :class="{ 'dropdown-submenu': hasSubregion(regionInfo)}">
-                                                    <a class="dropdown-item"
-                                                       :class="{ 'dropdown-toggle': hasSubregions }"
-                                                       @click="changeRegion(regionInfo.region)">
-                                                        <span v-text="regionInfo.region"></span>
-                                                    </a>
-                                                    <ul v-if="hasSubregions" class="dropdown-menu">
-                                                        <li>
-                                                            <a v-for="subregion in regionInfo.subregion"
-                                                               class="dropdown-item"
-                                                               @click="changeRegion(`${regionInfo.region}.${subregion}`)"
-                                                               v-text="i18n(subregion)">
-                                                            </a>
-                                                        </li>
-                                                    </ul>
-                                                </li>
+                                                <template v-for="(regionInfo, idx) in config.regions">
+                                                    <li>
+                                                        <a class="dropdown-item"
+                                                           @click.prevent="changeRegion(regionInfo.region)"
+                                                           v-text="i18n(regionInfo.region)">
+                                                        </a>
+                                                        <a v-for="subregion in regionInfo.subregion"
+                                                           class="dropdown-item"
+                                                           @click.prevent="changeRegion(`${regionInfo.region}.${subregion}`)"
+                                                           v-text="i18n(`${regionInfo.region}.${subregion}`)">
+                                                        </a>
+                                                    </li>
+                                                    <li v-if="idx !== (config.regions.length -1)" class="dropdown-divider m-0"></li>
+                                                </template>
                                             </ul>
                                         </li>
                                     </ul>

--- a/ngrinder-frontend/src/js/components/perftest/detail/Config.vue
+++ b/ngrinder-frontend/src/js/components/perftest/detail/Config.vue
@@ -25,7 +25,10 @@
                                              customStyle="width: 110px"
                                              :option="{ placeholder: i18n('perfTest.config.region.setting') }">
                                         <option></option>
-                                        <option v-for="region in config.regions" :value="region" v-text="i18n(region)"></option>
+                                        <optgroup v-for="regionInfo in config.regions" :label="regionInfo.region">
+                                            <option :value="regionInfo.region" v-text="i18n(regionInfo.region)"></option>
+                                            <option v-for="subregion in regionInfo.subregion" :value="`${regionInfo.region}.${subregion}`" v-text="i18n(subregion)"></option>
+                                        </optgroup>
                                     </select2>
                                     <input type="hidden" name="region" v-validate="{ regionValidation: true, required: true }" v-model="test.config.region"/>
                                 </div>

--- a/ngrinder-frontend/src/js/components/perftest/detail/Detail.vue
+++ b/ngrinder-frontend/src/js/components/perftest/detail/Detail.vue
@@ -432,15 +432,15 @@
             agentCountField.update({ rules: this.$refs.config.agentCountValidationRules });
 
             if (this.test.config.scm === 'svn') {
-                this.checkClonePerftestValidation();
+                this.checkClonedPerftestValidation();
                 return;
             }
 
             this.$refs.config.loadGitHubScript()
-                .then(this.checkClonePerftestValidation, this.clickConfigTabIfHasErrors);
+                .then(this.checkClonedPerftestValidation, this.clickConfigTabIfHasErrors);
         }
 
-        checkClonePerftestValidation() {
+        checkClonedPerftestValidation() {
             this.$validator.validateAll()
                 .then(() => {
                     if (this.errors.any()) {


### PR DESCRIPTION
Currently, if you run ngrinder in cluster mode, you can configure only one region for each controllers.
To improve this inefficiency, I allow to configure subregions under original region.

#### 1. How to configure the subregion.

You can configure the subregion by modifying the `system-ex.conf` file like below. Subregion only active in cluster mode.

```
...
ngrinder.cluster.region=korea
ngrinder.cluster.subregion=sub1,sub2
...
```

#### 2. Feature

1.  Agents can be divided and managed from one controller through subregion.
