### PR TITLE
Hide agent download link to general user in agent management page

### DIFF
--- a/ngrinder-frontend/src/js/components/agent/List.vue
+++ b/ngrinder-frontend/src/js/components/agent/List.vue
@@ -38,7 +38,7 @@
                     <span v-text="i18n('common.button.add')"></span>
                 </button>
             </div>
-            <div class="input-prepend ml-auto mt-auto mb-auto">
+            <div v-if="isAdmin" class="input-prepend ml-auto mt-auto mb-auto">
                 <div class="input-group-text" v-text="i18n('agent.list.download')"></div>
                 <div class="border rounded uneditable-input">
                     <template v-if="downloadLink">
@@ -267,7 +267,9 @@
             this.$refs.vuetable.currentPage = 1;
             clearTimeout(this.updateStatesTimer);
             this.updateStates();
-            this.updateDownloadLink();
+            if (this.isAdmin) {
+                this.updateDownloadLink();
+            }
         }
 
         search() {


### PR DESCRIPTION
Hide agent download link to general user in agent management page.

#### 1. Admin user

![image](https://user-images.githubusercontent.com/14273601/113974685-4c176b00-9879-11eb-9da6-840554a36fd1.png)

#### 2. General user

![image](https://user-images.githubusercontent.com/14273601/113974740-62bdc200-9879-11eb-9d3a-7ca320f0fe82.png)

