### PR TITLE
Change to use OSSRH for deployment ngrinder binary to maven central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-  id "com.jfrog.bintray" version "1.8.5"
-}
-
 allprojects  {
   apply plugin: "idea"
 
@@ -25,7 +21,8 @@ allprojects  {
 subprojects {
   apply plugin: "java"
   apply plugin: "maven-publish"
-  apply plugin: "com.jfrog.bintray"
+  apply plugin: "maven"
+  apply plugin: "signing"
 
   compileJava.options.encoding = "UTF-8"
   compileTestJava.options.encoding = "UTF-8"
@@ -69,66 +66,65 @@ subprojects {
     classifier "sources"
   }
 
-  publishing {
-    publications {
-      nGrinerModules(MavenPublication) {
-        from components.java
-        artifact sourceJar
-        artifact javadocJar
-        pom {
+  artifacts {
+    archives javadocJar, sourceJar
+  }
+
+  if (hasAllProperties("signing.keyId", "signing.password", "signing.secretKeyRingFile")) {
+    signing {
+      sign configurations.archives
+    }
+  }
+
+  uploadArchives {
+    repositories {
+      mavenDeployer {
+        beforeDeployment { deployment -> signing.signPom(deployment) }
+
+        if (hasAllProperties("ossrhUsername", "ossrhPassword")) {
+          repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+            authentication(userName: ossrhUsername, password: ossrhPassword)
+          }
+
+          snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+            authentication(userName: ossrhUsername, password: ossrhPassword)
+          }
+        }
+
+        pom.project {
           name = "org.ngrinder:${project.name}"
           description = "${project.name} module"
           url = "https://github.com/naver/ngrinder"
+
+          scm {
+            connection = "scm:git:git://github.com/naver/ngrinder.git"
+            developerConnection = "scm:git:ssh://github.com/naver/ngrinder.git"
+            url = "https://github.com/naver/ngrinder"
+          }
+
           licenses {
             license {
               name = "The Apache License, Version 2.0"
               url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
           }
-//          Below field is required to publish to the Maven central. Please modify before publishing.
-//          developers {
-//            developer {
-//              id = "{please_input_your_id}"
-//              name = "{please_input_your_name}"
-//              email = "{please_input_your_email}"
-//            }
-//          }
-          scm {
-            connection = "scm:git:git://github.com/naver/ngrinder.git"
-            developerConnection = "scm:git:ssh://github.com/naver/ngrinder.git"
-            url = "https://github.com/naver/ngrinder"
+
+          // Below field is required to publish to the Maven central. Please modify before publishing.
+          developers {
+            developer {
+              id = "{please_input_your_id}"
+              name = "{please_input_your_name}"
+              email = "{please_input_your_email}"
+            }
           }
+
         }
       }
     }
   }
 
-  bintray {
-    user =  project.hasProperty("bintrayUser") ? bintrayUser : ""
-    key =  project.hasProperty("bintrayKey") ? bintrayKey : ""
-    publications = ["nGrinerModules"]
-    publish = true
-    override = true
+}
 
-    pkg {
-      repo = "ngrinder"
-      name = project.name
-      userOrg = "navercorp"
-      licenses = ["Apache-2.0"]
-      websiteUrl = "https://github.com/naver/ngrinder"
-      issueTrackerUrl = "https://github.com/naver/ngrinder/issues"
-      vcsUrl = "https://github.com/naver/ngrinder.git"
-      labels = ["ngrinder"]
-      publicDownloadNumbers = true
-      version {
-        name = project.version
-        released = new Date()
-        gpg {
-          sign = true
-          passphrase = project.hasProperty("bintrayGpgPassphrase") ? bintrayGpgPassphrase : ""
-        }
-      }
-    }
-  }
-
+def hasAllProperties(String... keys) {
+  return keys.every() { key -> project.hasProperty(key) }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,12 @@ org.gradle.daemon=true
 jna.version=5.6.0
 groovy.version=3.0.5
 junit.version=4.13.1
+
+#signing.keyId={please_input_your_gpg_key}
+#signing.password={please_input_your_gpg_key_password}
+#signing.secretKeyRingFile={please_input_your_path_of_secring.gpg}
+
+#ossrhUsername={please_input_your_ossrh_username}
+#ossrhPassword={please_input_your_ossrh_password}
+
+#guide https://central.sonatype.org/publish/publish-gradle/


### PR DESCRIPTION
#### 1. Summary
Because deprecation of JFlog Bintray, I change to use OSSRH for deployment ngrinder binary to maven central.
It deploys to the staging repository first, and the artifacts can be released to maven central after checking that they meet the maven central's requirements.

#### 2. How to use

1. Fill in the commented properties in `gradle.properties`
3. Set `developer` settings in `build.gradle`
2. Run `./gradlew :ngrinder-{module_name}:uploadArchives`

#### 3. Result of deploy to the staging repository(before release to central, you can release after checking requirements)
<img src="https://user-images.githubusercontent.com/14273601/114594459-3c0fe900-9cc8-11eb-85ea-28749eca1048.png" width="280" height="300" />

#### 4. After Release to central

<img src="https://user-images.githubusercontent.com/14273601/114599872-a4fa5f80-9cce-11eb-864e-3cf1b4fa58f7.png" width="380" height="230" />
