### PR TITLE
Fix that perftest detail report does not rendered properly if logout

### DIFF
--- a/ngrinder-frontend/src/js/main.js
+++ b/ngrinder-frontend/src/js/main.js
@@ -110,7 +110,7 @@ Vue.directive('visible', (el, binding) => {
 Vue.filter('numFormat', numFormat(numeral));
 Vue.filter('dateFormat', (value, format) => {
     if (value) {
-        return moment(new Date(value)).tz(ngrinder.currentUser.timeZone).format(format);
+        return moment(new Date(value)).tz(ngrinder.currentUser.timeZone || moment.tz.guess(true)).format(format);
     }
     return '';
 });


### PR DESCRIPTION
Fix #803

if `ngrinder.currentUser.timeZone` isn't set(no login), It use [moment.tz.guess()](https://momentjs.com/timezone/docs/#/using-timezones/guessing-user-timezone/) for default value.