### PR TITLE
Remove `ngrinder-kr` gitter badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ You can join our forum as well
 * User Forum : http://ngrinder.373.s1.nabble.com/ngrinder-user-f50.html
 * 中文论坛 (Chinese) : http://ngrinder.373.s1.nabble.com/ngrinder-user-cn-f114.html
 * 한국어 유저 포럼 (Korean): http://ngrinder.373.s1.nabble.com/ngrinder-user-kr-f113.html
-* [![Developer chat at https://gitter.im/naver/ngrinder-kr](https://badges.gitter.im/naver/ngrinder-kr.svg)](https://gitter.im/naver/ngrinder-kr?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 
 License


### PR DESCRIPTION
Looks like `naver/ngrinder-kr` chat is not available now