### PR TITLE
Improve GRADLE build Performance

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@ org.gradle.daemon=true
 jna.version=5.6.0
 groovy.version=3.0.5
 junit.version=4.13.1
+org.gradle.caching = true
 
 #signing.keyId={please_input_your_gpg_key}
 #signing.password={please_input_your_gpg_key_password}


### PR DESCRIPTION

[gradle caching](https://docs.gradle.org/current/userguide/build_cache.html). Shared caches can reduce the number of tasks you need to execute by reusing outputs already generated elsewhere. This can significantly decrease build times. We can enable this feature by setting `org.gradle.caching=true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
