### PR TITLE
Add InetAddress reachable check

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/config/DynamicCacheConfig.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/config/DynamicCacheConfig.java
@@ -39,7 +39,6 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static net.grinder.util.NetworkUtils.DEFAULT_LOCAL_HOST_ADDRESS;
 import static org.apache.commons.lang.ArrayUtils.EMPTY_STRING_ARRAY;
 import static org.ngrinder.common.constant.CacheConstants.*;
 import static org.ngrinder.common.util.ObjectUtils.defaultIfNull;
@@ -109,7 +108,7 @@ public class DynamicCacheConfig implements ClusterConstants {
 			String[] clusterURIs = defaultIfNull(getClusterURIs(), EMPTY_STRING_ARRAY);
 
 			if ("easy".equals(clusterMode)) {
-				tcpIpConfig.addMember(DEFAULT_LOCAL_HOST_ADDRESS);
+				tcpIpConfig.addMember(NetworkUtils.getLocalHostAddress());
 			} else {
 				networkConfig.setPort(getClusterPort()).setPortAutoIncrement(false);
 				if (clusterURIs.length > 0) {
@@ -243,7 +242,7 @@ public class DynamicCacheConfig implements ClusterConstants {
 	}
 
 	private String getClusterHostName() {
-		String hostName = config.getClusterProperties().getProperty(PROP_CLUSTER_HOST, DEFAULT_LOCAL_HOST_ADDRESS);
+		String hostName = config.getClusterProperties().getProperty(PROP_CLUSTER_HOST, NetworkUtils.getLocalHostAddress());
 		try {
 			//noinspection ResultOfMethodCallIgnored
 			InetAddress.getByName(hostName);

--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/hazelcast/task/RegionInfoTask.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/hazelcast/task/RegionInfoTask.java
@@ -1,6 +1,7 @@
 package org.ngrinder.infra.hazelcast.task;
 
 import com.hazelcast.spring.context.SpringAware;
+import net.grinder.util.NetworkUtils;
 import org.ngrinder.infra.config.Config;
 import org.ngrinder.region.model.RegionInfo;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,7 +11,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
-import static net.grinder.util.NetworkUtils.DEFAULT_LOCAL_HOST_ADDRESS;
 import static org.apache.commons.lang.StringUtils.defaultIfBlank;
 import static org.ngrinder.common.constant.CacheConstants.REGION_ATTR_KEY;
 import static org.ngrinder.common.constant.CacheConstants.SUBREGION_ATTR_KEY;
@@ -28,7 +28,7 @@ public class RegionInfoTask implements Callable<RegionInfo>, Serializable {
 	private transient Config config;
 
 	public RegionInfo call() {
-		final String regionIP = defaultIfBlank(config.getCurrentIP(), DEFAULT_LOCAL_HOST_ADDRESS);
+		final String regionIP = defaultIfBlank(config.getCurrentIP(), NetworkUtils.getLocalHostAddress());
 		Map<String, String> regionWithSubregion = config.getRegionWithSubregion();
 		Set<String> subregion = convertSubregionsStringToSet(regionWithSubregion.get(SUBREGION_ATTR_KEY));
 		return new RegionInfo(regionWithSubregion.get(REGION_ATTR_KEY), subregion, regionIP, config.getControllerPort());

--- a/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/ConsoleManager.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/perftest/service/ConsoleManager.java
@@ -18,6 +18,7 @@ import net.grinder.SingleConsole;
 import net.grinder.console.communication.ConsoleCommunicationImplementationEx;
 import net.grinder.console.model.ConsoleCommunicationSetting;
 import net.grinder.console.model.ConsoleProperties;
+import net.grinder.util.NetworkUtils;
 import org.apache.commons.lang.StringUtils;
 import org.ngrinder.infra.config.Config;
 import org.ngrinder.perftest.model.NullSingleConsole;
@@ -34,7 +35,6 @@ import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
-import static net.grinder.util.NetworkUtils.DEFAULT_LOCAL_HOST_ADDRESS;
 import static net.grinder.util.NetworkUtils.getAvailablePorts;
 import static org.apache.commons.lang.StringUtils.defaultIfEmpty;
 import static org.ngrinder.common.constant.ControllerConstants.*;
@@ -72,7 +72,7 @@ public class ConsoleManager {
 	public void init() {
 		int consoleSize = getConsoleSize();
 		consoleQueue = new ArrayBlockingQueue<>(consoleSize);
-		final String currentIP = defaultIfEmpty(config.getCurrentIP(), DEFAULT_LOCAL_HOST_ADDRESS);
+		final String currentIP = defaultIfEmpty(config.getCurrentIP(), NetworkUtils.getLocalHostAddress());
 		for (int port : getAvailablePorts(currentIP, consoleSize, getConsolePortBase(), MAX_PORT_NUMBER)) {
 			final ConsoleEntry consoleEntry = new ConsoleEntry(currentIP, port);
 			try {
@@ -150,7 +150,7 @@ public class ConsoleManager {
 					consoleCommunicationSetting.setInactiveClientTimeOut(config.getInactiveClientTimeOut());
 				}
 				SingleConsole singleConsole = new SingleConsole(config.getCurrentIP(), consoleEntry.getPort(),
-						consoleCommunicationSetting, baseConsoleProperties);
+					consoleCommunicationSetting, baseConsoleProperties);
 				getConsoleInUse().add(singleConsole);
 				singleConsole.setCsvSeparator(config.getCsvSeparator());
 				return singleConsole;
@@ -180,7 +180,7 @@ public class ConsoleManager {
 			console.sendStopMessageToAgents();
 		} catch (Exception e) {
 			LOG.error("Exception occurred during console return back for test {}.",
-					testIdentifier, e);
+				testIdentifier, e);
 			// But the port is getting back.
 		} finally {
 			// This is very careful implementation..
@@ -189,7 +189,7 @@ public class ConsoleManager {
 				console.waitUntilAllAgentDisconnected();
 			} catch (Exception e) {
 				LOG.error("Exception occurred during console return back for test {}.",
-						testIdentifier, e);
+					testIdentifier, e);
 				// If it's not disconnected still, stop them by force.
 				agentManager.stopAgent(console.getConsolePort());
 			}
@@ -197,7 +197,7 @@ public class ConsoleManager {
 				console.shutdown();
 			} catch (Exception e) {
 				LOG.error("Exception occurred during console return back for test {}.",
-						testIdentifier, e);
+					testIdentifier, e);
 			}
 			int consolePort;
 			String consoleIP;

--- a/ngrinder-controller/src/main/java/org/ngrinder/region/service/RegionService.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/region/service/RegionService.java
@@ -16,8 +16,8 @@ package org.ngrinder.region.service;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.Maps;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.cluster.Member;
+import com.hazelcast.core.HazelcastInstance;
 import lombok.RequiredArgsConstructor;
 import net.grinder.util.NetworkUtils;
 import org.apache.commons.lang.StringUtils;
@@ -66,7 +66,7 @@ public class RegionService {
 					regions.put(regionInfo.getRegionName(), regionInfo);
 				}
 			} else {
-				final String regionIP = StringUtils.defaultIfBlank(config.getCurrentIP(), NetworkUtils.DEFAULT_LOCAL_HOST_ADDRESS);
+				final String regionIP = StringUtils.defaultIfBlank(config.getCurrentIP(), NetworkUtils.getLocalHostAddress());
 				regions.put(config.getRegion(), new RegionInfo(config.getRegion(), emptySet(), regionIP, config.getControllerPort()));
 			}
 			return regions;
@@ -109,7 +109,7 @@ public class RegionService {
 		String localRegion = getCurrent();
 		RegionInfo regionInfo = regions.get(localRegion);
 		if (regionInfo != null && !StringUtils.equals(regionInfo.getIp(), config.getClusterProperties().getProperty
-			(ClusterConstants.PROP_CLUSTER_HOST, NetworkUtils.DEFAULT_LOCAL_HOST_ADDRESS))) {
+			(ClusterConstants.PROP_CLUSTER_HOST, NetworkUtils.getLocalHostAddress()))) {
 			throw processException("The region name, " + localRegion
 				+ ", is already used by other controller " + regionInfo.getIp()
 				+ ". Please set the different region name in this controller.");
@@ -165,11 +165,11 @@ public class RegionService {
 	public List<Map<String, Object>> getAllVisibleRegionNames() {
 		if (config.isClustered()) {
 			return allRegionNames.get().stream().map(region -> {
-					Map<String, Object> regionInfo = new HashMap<>();
-					String subregionAttributes = region.get(SUBREGION_ATTR_KEY);
-					regionInfo.put(REGION_ATTR_KEY, region.get(REGION_ATTR_KEY));
-					regionInfo.put(SUBREGION_ATTR_KEY, convertSubregionsStringToSet(subregionAttributes));
-					return regionInfo;
+				Map<String, Object> regionInfo = new HashMap<>();
+				String subregionAttributes = region.get(SUBREGION_ATTR_KEY);
+				regionInfo.put(REGION_ATTR_KEY, region.get(REGION_ATTR_KEY));
+				regionInfo.put(SUBREGION_ATTR_KEY, convertSubregionsStringToSet(subregionAttributes));
+				return regionInfo;
 			}).collect(toList());
 		} else {
 			return emptyList();

--- a/ngrinder-controller/src/test/java/org/ngrinder/infra/config/DynamicCacheConfigTest.java
+++ b/ngrinder-controller/src/test/java/org/ngrinder/infra/config/DynamicCacheConfigTest.java
@@ -17,13 +17,13 @@ public class DynamicCacheConfigTest {
 
 	@Test
 	public void testLocalHost() {
-		IPPortPair pair = new IPPortPair(NetworkUtils.DEFAULT_LOCAL_HOST_ADDRESS, 10);
+		IPPortPair pair = new IPPortPair(NetworkUtils.getLocalHostAddress(), 10);
 		assertThat(pair.isLocalHost()).isTrue();
 
 		pair = new IPPortPair("10.10.10.10", 10);
 		assertThat(pair.isLocalHost()).isFalse();
 
-		for (InetAddress each : NetworkUtils.DEFAULT_LOCAL_ADDRESSES) {
+		for (InetAddress each : NetworkUtils.getAllLocalNonLoopbackAddresses(false)) {
 			if (each instanceof Inet6Address) {
 				final String hostAddress = each.getHostAddress();
 				assertThat(new IPPortPair("[" + hostAddress + "]", 10).isLocalHost()).isTrue();

--- a/ngrinder-core/src/main/java/net/grinder/engine/agent/AgentImplementationEx.java
+++ b/ngrinder-core/src/main/java/net/grinder/engine/agent/AgentImplementationEx.java
@@ -143,7 +143,7 @@ public class AgentImplementationEx implements Agent, AgentConstants {
 					properties = createAndMergeProperties(grinderProperties,
 							startMessage != null ? startMessage.getProperties() : null);
 					if (m_agentConfig.isConnectionMode()) {
-						properties.setProperty(GrinderProperties.CONSOLE_HOST, NetworkUtils.DEFAULT_LOCAL_HOST_ADDRESS);
+						properties.setProperty(GrinderProperties.CONSOLE_HOST, NetworkUtils.getLocalHostAddress());
 						properties.setInt(GrinderProperties.CONSOLE_PORT, connectionPort);
 					} else {
 						properties.setProperty(GrinderProperties.CONSOLE_HOST, m_agentConfig.getControllerIP());

--- a/ngrinder-core/src/main/java/net/grinder/util/NetworkUtils.java
+++ b/ngrinder-core/src/main/java/net/grinder/util/NetworkUtils.java
@@ -52,9 +52,6 @@ import static org.ngrinder.common.util.NoOp.noOp;
 @SuppressWarnings("SameParameterValue")
 public abstract class NetworkUtils {
 	private static final Logger LOGGER = LoggerFactory.getLogger(NetworkUtils.class);
-	public static String DEFAULT_LOCAL_HOST_ADDRESS = getLocalHostAddress();
-	public static String DEFAULT_LOCAL_HOST_NAME = getLocalHostName();
-	public static List<InetAddress> DEFAULT_LOCAL_ADDRESSES = getAllLocalNonLoopbackAddresses(false);
 
 	/**
 	 * Get the local host address, try to get actual IP.
@@ -147,7 +144,7 @@ public abstract class NetworkUtils {
 	}
 
 	static InetAddress getFirstNonLoopbackAddress(boolean preferIpv4, boolean preferIPv6)
-			throws SocketException {
+		throws SocketException {
 		Enumeration<?> en = getNetworkInterfaces();
 		while (en.hasMoreElements()) {
 			NetworkInterface i = (NetworkInterface) en.nextElement();
@@ -214,8 +211,8 @@ public abstract class NetworkUtils {
 	/**
 	 * Get the available ports.
 	 *
-	 * @param size port size
-	 * @param from port number starting from
+	 * @param size  port size
+	 * @param from  port number starting from
 	 * @param limit number of max port
 	 * @return port list
 	 */
@@ -475,7 +472,7 @@ public abstract class NetworkUtils {
 	}
 
 
-	private static List<InetAddress> getAllLocalNonLoopbackAddresses(boolean onlyIPv4) {
+	public static List<InetAddress> getAllLocalNonLoopbackAddresses(boolean onlyIPv4) {
 		List<InetAddress> addresses = new ArrayList<>();
 		final Enumeration<NetworkInterface> networkInterfaces;
 		try {

--- a/ngrinder-core/src/main/java/org/ngrinder/NGrinderAgentStarter.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/NGrinderAgentStarter.java
@@ -33,7 +33,8 @@ import java.util.Properties;
 import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
 import static net.grinder.util.NetworkUtils.getIP;
-import static org.apache.commons.lang.StringUtils.*;
+import static org.apache.commons.lang.StringUtils.isBlank;
+import static org.apache.commons.lang.StringUtils.isNotEmpty;
 import static org.ngrinder.common.constants.InternalConstants.PROP_INTERNAL_NGRINDER_VERSION;
 import static org.ngrinder.common.util.SystemInfoUtils.*;
 
@@ -134,9 +135,7 @@ public class NGrinderAgentStarter implements AgentConstants, CommonConstants {
 		if (agentConfig.isConnectionMode()) {
 			LOG.info("waiting for connection on {}:{}", agentConfig.getBroadcastIP(), agentConfig.getConnectionAgentPort());
 		} else {
-			String controllerIP = getIP(agentConfig.getControllerHost());
-			agentConfig.setControllerIP(controllerIP);
-			LOG.info("connecting to controller {}:{}", controllerIP, agentConfig.getControllerPort());
+			LOG.info("connecting to controller {}:{}", getIP(agentConfig.getControllerHost()), agentConfig.getControllerPort());
 		}
 
 		try {

--- a/ngrinder-core/src/main/java/org/ngrinder/infra/AgentConfig.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/infra/AgentConfig.java
@@ -35,7 +35,6 @@ import java.io.InputStream;
 import java.util.Properties;
 import java.util.Set;
 
-import static net.grinder.util.NetworkUtils.DEFAULT_LOCAL_HOST_ADDRESS;
 import static org.apache.commons.io.FileUtils.deleteQuietly;
 import static org.apache.commons.lang.StringUtils.defaultIfEmpty;
 import static org.apache.commons.lang.StringUtils.trimToEmpty;
@@ -321,7 +320,7 @@ public class AgentConfig implements AgentConstants, MonitorConstants, CommonCons
 	}
 
 	public String getControllerHost() {
-		return getAgentProperties().getProperty(PROP_AGENT_CONTROLLER_HOST, DEFAULT_LOCAL_HOST_ADDRESS);
+		return getAgentProperties().getProperty(PROP_AGENT_CONTROLLER_HOST, NetworkUtils.getLocalHostAddress());
 	}
 
 	public void setControllerIP(String ip) {
@@ -329,7 +328,7 @@ public class AgentConfig implements AgentConstants, MonitorConstants, CommonCons
 	}
 
 	public String getControllerIP() {
-		return defaultIfEmpty(controllerIP, DEFAULT_LOCAL_HOST_ADDRESS);
+		return defaultIfEmpty(controllerIP, NetworkUtils.getLocalHostAddress());
 	}
 
 	public int getControllerPort() {
@@ -353,7 +352,7 @@ public class AgentConfig implements AgentConstants, MonitorConstants, CommonCons
 	}
 
 	public String getAgentHostID() {
-		return getAgentProperties().getProperty(PROP_AGENT_HOST_ID, NetworkUtils.DEFAULT_LOCAL_HOST_NAME);
+		return getAgentProperties().getProperty(PROP_AGENT_HOST_ID, NetworkUtils.getLocalHostName());
 	}
 
 	public boolean isSecurityEnabled() {
@@ -370,7 +369,7 @@ public class AgentConfig implements AgentConstants, MonitorConstants, CommonCons
 	}
 
 	public String getBroadcastIP() {
-		return getAgentProperties().getProperty(PROP_AGENT_BROADCAST_IP, NetworkUtils.DEFAULT_LOCAL_HOST_ADDRESS);
+		return getAgentProperties().getProperty(PROP_AGENT_BROADCAST_IP, NetworkUtils.getLocalHostAddress());
 	}
 
 	public boolean isSilentMode() {

--- a/ngrinder-core/src/test/java/net/grinder/util/NetworkUtilTest.java
+++ b/ngrinder-core/src/test/java/net/grinder/util/NetworkUtilTest.java
@@ -18,16 +18,18 @@ import org.junit.Test;
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.List;
 
-import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 public class NetworkUtilTest {
 
 	@Test
 	public void testLocalAddresses() {
-		assertThat(NetworkUtils.DEFAULT_LOCAL_ADDRESSES.size(), not(0));
-		for (InetAddress each : NetworkUtils.DEFAULT_LOCAL_ADDRESSES) {
+		List<InetAddress> localAddresses = NetworkUtils.getAllLocalNonLoopbackAddresses(false);
+		assertThat(localAddresses.size(), not(0));
+		for (InetAddress each : localAddresses) {
 			assertThat(each.getHostAddress(), not(containsString("127.0.0.1")));
 		}
 	}
@@ -35,14 +37,14 @@ public class NetworkUtilTest {
 	@Test
 	public void testIPAndPortPair() {
 		NetworkUtils.IPPortPair ipAndPortPair = NetworkUtils.convertIPAndPortPair
-				("2001:0:9d38:90d7:469:1f94:f5bf:cf5d", 0);
+			("2001:0:9d38:90d7:469:1f94:f5bf:cf5d", 0);
 		assertThat(ipAndPortPair.getIP(), is("2001:0:9d38:90d7:469:1f94:f5bf:cf5d"));
 		assertThat(ipAndPortPair.getPort(), is(0));
 		ipAndPortPair = NetworkUtils.convertIPAndPortPair("[2001:0:9d38:90d7:469:1f94:f5bf:cf5d]:20", 0);
 		assertThat(ipAndPortPair.getIP(), is("2001:0:9d38:90d7:469:1f94:f5bf:cf5d"));
 		assertThat(ipAndPortPair.getPort(), is(20));
 		ipAndPortPair = NetworkUtils.convertIPAndPortPair
-				("2001:0:9d38:90d7:469:1f94:f5bf:cf5d", 0);
+			("2001:0:9d38:90d7:469:1f94:f5bf:cf5d", 0);
 		assertThat(ipAndPortPair.getIP(), is("2001:0:9d38:90d7:469:1f94:f5bf:cf5d"));
 		assertThat(ipAndPortPair.getPort(), is(0));
 		ipAndPortPair = NetworkUtils.convertIPAndPortPair("127.0.0.1:20", 0);


### PR DESCRIPTION
resolved: https://github.com/naver/ngrinder/issues/885

On macOS, `InetAddress.getLocalHost()` returns weired address and it derives no port available exception. 
Available port check is executed with the wrong IP address, so the controller can not acquire any ports.

---

After digging a few days, It comes out not an application bug, it is a kind of PC settings issue.
No major logic changes in this PR. I just make it clearer how to deal with this issue.