### PR TITLE
Remove es-check gradle task

### DIFF
--- a/ngrinder-controller/build.gradle
+++ b/ngrinder-controller/build.gradle
@@ -112,4 +112,3 @@ test {
 tasks.bootWar.dependsOn convert_cr_lf
 
 tasks.processResources.finalizedBy tasks.getByPath(":ngrinder-frontend:webpack")
-tasks.processResources.finalizedBy tasks.getByPath(":ngrinder-frontend:checkES5")

--- a/ngrinder-frontend/build.gradle
+++ b/ngrinder-frontend/build.gradle
@@ -14,9 +14,3 @@ task webpack(dependsOn: "npmInstall", type: NodeTask) {
         args = ["--$profile"]
     }
 }
-
-task checkES5(type: NpxTask) {
-    command = "es-check@$esCheckModuleVersion"
-    args = ["es5", "../ngrinder-controller/build/classes/main/static/js/app.js", "--verbose"]
-    ignoreExitValue = true
-}


### PR DESCRIPTION
Resolved: #895

Main role of the `es-check` task was to detect IE compatibility issues.
Since the IE has retired, remove the `es-check` task. 
We expect that the most of modern web browers are compatible.