### PR TITLE
Fix the script content is lost after validation check

### DIFF
--- a/ngrinder-frontend/src/js/components/script/Editor.vue
+++ b/ngrinder-frontend/src/js/components/script/Editor.vue
@@ -298,7 +298,7 @@
             this.$http.post('/script/api/save', params)
             .then(() => {
                 this.showSuccessMsg(this.i18n('common.message.alert.save.success'));
-                this.file.content = this.$refs.editor.getValue();
+                this.$refs.editor.codemirror.setValue(this.$refs.editor.getValue());
                 if (isClose) {
                     this.$router.push('/script/list/');
                 }


### PR DESCRIPTION
Resolve  #884

Sometimes script contents are missing after validation check.
This error can be reproduced by steps described below.
1. Edit script contents
2. Save the script
3. Edit script contents
4. Validate the script

There're no codes to change or assign the script contents in script validation function.
This error looks like a timing issue that caused by handling vue component status on both child and parent.

After chaning the script contents assigning to child component method invocation, the error case is not occured anymore in my environment.