### PR TITLE
Fix scm-manager maven repo url

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ subprojects {
   repositories {
     mavenCentral()
     maven { url "https://repo.springsource.org/release" }
-    maven { url "https://maven.scm-manager.org/nexus/content/repositories/releases" }
+    maven { url "https://packages.scm-manager.org/repository/releases" }
   }
 
   test {


### PR DESCRIPTION
Change `scm-manager` maven repository URL.
* Before: https://maven.scm-manager.org/nexus/content/repositories/releases
* After : https://packages.scm-manager.org/repository/releases

When enter the before URL on a web browser, it redirects to the after URL.
I think the before URL is no more supported. 
I checked that gradle can resolve the svnkit dependency after changing the maven repo URL.

But, [maven respository official website](https://mvnrepository.com/repos/scm-manager-releases) still introduces the legacy URL. It confuse me...
