### PR TITLE
Fix docker agent set up

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -10,9 +10,9 @@ nGrinder is a platform for stress tests that enables you to execute script creat
 
 nGrinder consists of two major components. 
 
-* __controller__ : a web application that enables the performance tester to create a test script and configure a test run. You can get the controller docker images [ngrinder/controller](https://registry.hub.docker.com/u/ngrinder/controller/).
+* __controller__ : a web application that enables the performance tester to create a test script and configure a test run. You can get the controller docker images [ngrinder/controller](https://registry.hub.docker.com/r/ngrinder/controller).
 
-* __agent__ : a virtual user generator that creates loads. You can get the agent docker images [ngrinder/agent](https://registry.hub.docker.com/u/ngrinder/agent/).
+* __agent__ : a virtual user generator that creates loads. You can get the agent docker images [ngrinder/agent](https://registry.hub.docker.com/r/ngrinder/agent).
 
 Version
 ---------
@@ -27,13 +27,13 @@ Install docker 1.5.0 or above  on your host.
 Pull the ngrinder/controller image.
 
 ```
-$ docker pull ngrinder-controller:3.4
+$ docker pull ngrinder/controller:3.5.6
 ```
 
 Start controller.
 
 ```
-docker run -d -v ~/ngrinder-controller:/opt/ngrinder-controller -p 80:80 -p 16001:16001 -p 12000-12009:12000-12009 ngrinder-controller:3.4
+docker run -d -v ~/ngrinder-controller:/opt/ngrinder-controller -p 80:80 -p 16001:16001 -p 12000-12009:12000-12009 ngrinder/controller:3.5.6
 ``` 
 
 The controller creates a data folder under /opt/ngrinder-controller to maintain test history and configuration data. In order to keep the data persistently, you should map the folder /opt/ngrinder-controller on the container to a folder on your host . 
@@ -54,11 +54,11 @@ Install docker 1.5.0 or above on your another host. You should run your agent on
 Pull the ngrinder/agent image.
 
 ```
-$ docker pull ngrinder/agent:3.4
+$ docker pull ngrinder/agent:3.5.6
 ```
 
 Start agent.
 
 ```
-docker run -v ~/ngrinder-agent:/opt/ngrinder-agent -d ngrinder/agent:3.4 controller_ip:controller_web_port
+docker run -v ~/ngrinder-agent:/opt/ngrinder-agent -d ngrinder/agent:3.5.6 controller_ip:controller_web_port
 ``` 

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -1,7 +1,7 @@
 FROM jeanblanchard/java:serverjre-8
 MAINTAINER JunHo Yoon "junoyoon@gmail.com"
 
-RUN apk update; apk add curl bash
+RUN apk update; apk add curl bash udev
 
 
 # Set up environment variables


### PR DESCRIPTION
I tried to release Docker images and tested v3.5.6. But, there is a little problem on agent running.
Related issue is https://github.com/oshi/oshi/issues/271. 
The agent can not run with printing error log below.
<details><summary>Click to see error log</summary>
<p>

```
Connecting to ___.___.___.___:80 (___.___.___.___:80)
Connecting to ___.___.___.___ (___.___.___.___:80)
ngrinder-agent.tar   100% |****************************************************| 76.0M  0:00:00 ETA
ngrinder-agent/
ngrinder-agent/lib/
ngrinder-agent/run_agent_bg.sh
ngrinder-agent/stop_agent.sh
ngrinder-agent/run_agent.bat
ngrinder-agent/run_agent_internal.bat
ngrinder-agent/run_agent.sh
ngrinder-agent/run_agent_internal.sh
ngrinder-agent/stop_agent.bat
ngrinder-agent/lib/ngrinder-core-3.5.6.jar
ngrinder-agent/lib/jackson-databind-2.11.2.jar
ngrinder-agent/lib/jackson-annotations-2.11.2.jar
ngrinder-agent/lib/jcommander-1.32.jar
ngrinder-agent/lib/pf4j-3.0.1.jar
ngrinder-agent/lib/commons-collections-3.2.1.jar
ngrinder-agent/lib/ngrinder-groovy-3.5.6.jar
ngrinder-agent/lib/commons-compress-1.4.1.jar
ngrinder-agent/lib/oshi-core-6.1.6.jar
ngrinder-agent/lib/javax.servlet-api-4.0.1.jar
ngrinder-agent/lib/jna-platform-5.11.0.jar
ngrinder-agent/lib/jna-5.11.0.jar
ngrinder-agent/lib/commons-codec-1.14.jar
ngrinder-agent/lib/ngrinder-runtime-3.5.6.jar
ngrinder-agent/lib/grinder-http-3.9.1.jar
ngrinder-agent/lib/grinder-core-3.9.1.jar
ngrinder-agent/lib/logback-classic-1.2.3.jar
ngrinder-agent/lib/jcl-over-slf4j-1.7.30.jar
ngrinder-agent/lib/dnsjava-3.2.2.jar
ngrinder-agent/lib/slf4j-api-1.7.30.jar
ngrinder-agent/lib/hibernate-core-5.4.20.Final.jar
ngrinder-agent/lib/jboss-transaction-api_1.2_spec-1.1.1.Final.jar
ngrinder-agent/lib/hibernate-commons-annotations-5.1.0.Final.jar
ngrinder-agent/lib/jboss-logging-3.4.1.Final.jar
ngrinder-agent/lib/commons-io-2.6.jar
ngrinder-agent/lib/jackson-core-2.11.2.jar
ngrinder-agent/lib/java-semver-0.9.0.jar
ngrinder-agent/lib/javassist-3.24.0-GA.jar
ngrinder-agent/lib/groovy-datetime-3.0.5.jar
ngrinder-agent/lib/groovy-templates-3.0.5.jar
ngrinder-agent/lib/groovy-json-3.0.5.jar
ngrinder-agent/lib/groovy-sql-3.0.5.jar
ngrinder-agent/lib/groovy-xml-3.0.5.jar
ngrinder-agent/lib/groovy-3.0.5.jar
ngrinder-agent/lib/xz-1.0.jar
ngrinder-agent/lib/logback-core-1.2.3.jar
ngrinder-agent/lib/javax.persistence-api-2.2.jar
ngrinder-agent/lib/byte-buddy-1.10.14.jar
ngrinder-agent/lib/antlr-2.7.7.jar
ngrinder-agent/lib/jandex-2.1.3.Final.jar
ngrinder-agent/lib/classmate-1.5.1.jar
ngrinder-agent/lib/jaxb-api-2.3.1.jar
ngrinder-agent/lib/javax.activation-api-1.2.0.jar
ngrinder-agent/lib/dom4j-2.1.3.jar
ngrinder-agent/lib/jaxb-runtime-2.3.3.jar
ngrinder-agent/lib/junit-4.13.1.jar
ngrinder-agent/lib/commons-lang-2.6.jar
ngrinder-agent/lib/jython-standalone-2.7.2.jar
ngrinder-agent/lib/json-20090211.jar
ngrinder-agent/lib/hamcrest-all-1.1.jar
ngrinder-agent/lib/asm-9.0.jar
ngrinder-agent/lib/httpcore5-h2-5.0.3.jar
ngrinder-agent/lib/txw2-2.3.3.jar
ngrinder-agent/lib/istack-commons-runtime-3.0.11.jar
ngrinder-agent/lib/hamcrest-core-2.2.jar
ngrinder-agent/lib/grinder-dcr-agent-3.9.1.jar
ngrinder-agent/lib/httpcore5-5.0.3.jar
ngrinder-agent/lib/grinder-httpclient-3.9.1.jar
ngrinder-agent/lib/picocontainer-2.13.6.jar
ngrinder-agent/__agent.conf
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
2022-10-07 08:31:33,654 INFO  agent config: The path to ngrinder agent home is ambiguous:
2022-10-07 08:31:33,659 INFO  agent config:     '' is accepted.
2022-10-07 08:31:33,660 INFO  agent config: NGRINDER_AGENT_HOME : /opt/ngrinder-agent/.ngrinder-agent
2022-10-07 08:31:33,661 INFO  agent config: Overwrite the existing agent.conf with __agent.conf
Exception in thread "main" java.lang.UnsatisfiedLinkError: Unable to load library 'udev':
libudev.so: cannot open shared object file: No such file or directory
libudev.so: cannot open shared object file: No such file or directory
Native library (linux-x86-64/libudev.so) not found in resource path ([file:/opt/ngrinder-agent/lib/ngrinder-core-3.5.6.jar, file:/opt/ngrinder-agent/lib/ngrinder-runime-3.5.6.jar, file:/opt/ngrinder-agent/lib/logback-classic-1.2.3.jar, file:/opt/ngrinder-agent/lib/hibernate-core-5.4.20.Final.jar, file:/opt/ngrinder-agent/lib/dnsjava-3.2.2.jar, file:/opt/ngrinder-agent/lib/istack-commons-runtime-3.0.11.jar, file:/opt/ngrinder-agent/lib/jaxb-api-2.3.1.jar, file:/opt/ngrinder-agent/lib/byte-buddy-1.10.14.jar, file:/opt/ngrinder-agent/lib/json-20090211.jar, file:/opt/ngrinder-agent/lib/groovy-sql-3.0.5.jar, file:/opt/ngrinder-agent/lib/commons-compress-1.4.1.jar, file:/opt/ngrinder-agent/lib/commons-codec-1.14.jar, file:/opt/ngrinder-agent/lib/grinder-dcr-agent-3.9.1.jar, file:/opt/ngrinder-agent/lib/commons-io-2.6.jar, file:/opt/ngrinder-agent/lib/hamcrest-core-2.2.jar, file:/opt/ngrinder-agent/lib/jboss-logging-3.4.1.Final.jar, file:/opt/ngrinder-agent/lib/jackson-annotations-2.11.2.jar, file:/opt/ngrinder-agent/lib/picocontainer-2.13.6.jar, file:/opt/ngrinder-agent/lib/grinder-http-3.9.1.jar, file:/opt/ngrinder-agent/lib/asm-9.0.jar, file:/opt/ngrinder-agent/lib/ngrinder-core-3.5.6.jar, file:/opt/ngrinder-agent/lib/jaxb-runtime-2.3.3.jar, file:/opt/ngrinder-agent/lib/groovy-json-3.0.5.jar, file:/opt/ngrinder-agent/lib/xz-1.0.jar, file:/opt/ngrinder-agent/lib/jython-standalone-2.7.2.jar, file:/opt/ngrinder-agent/lib/jboss-transaction-api_1.2_spec-1.1.1.Final.jar, file:/opt/ngrinder-agent/lib/httpcore5-h2-5.0.3.jar, file:/opt/ngrinder-agent/lib/jna-platform-5.11.0.jar, file:/opt/ngrinder-agent/lib/jna-5.11.0.jar, file:/opt/ngrinder-agent/lib/classmate-1.5.1.jar, file:/opt/ngrinder-agent/lib/antlr-2.7.7.jar, file:/opt/ngrinder-agent/lib/pf4j-3.0.1.jar, file:/opt/ngrinder-agent/lib/javax.activation-api-1.2.0.jar, file:/opt/ngrinder-agent/lib/jackson-core-2.11.2.jar, file:/opt/ngrinder-agent/lib/groovy-3.0.5.jar, file:/opt/ngrinder-agent/lib/hamcrest-all-1.1.jar, file:/opt/ngrinder-agent/lib/commons-lang-2.6.jar, file:/opt/ngrinder-agent/lib/txw2-2.3.3.jar, file:/opt/ngrinder-agent/lib/hibernate-commons-annotations-5.1.0.Final.jar, file:/opt/ngrinder-agent/lib/jcl-over-slf4j-1.7.30.jar, file:/opt/ngrinder-agent/lib/javax.servlet-api-4.0.1.jar, file:/opt/ngrinder-agent/lib/ngrinder-groovy-3.5.6.jar, file:/opt/ngrinder-agent/lib/dom4j-2.1.3.jar, file:/opt/ngrinder-agent/lib/groovy-datetime-3.0.5.jar, file:/opt/ngrinder-agent/lib/jcommander-1.32.jar, file:/opt/ngrinder-agent/lib/groovy-templates-3.0.5.jar, file:/opt/ngrinder-agent/lib/jackson-databind-2.11.2.jar, file:/opt/ngrinder-agent/lib/javax.persistence-api-2.2.jar, file:/opt/ngrinder-agent/lib/grinder-httpclient-3.9.1.jar, file:/opt/ngrinder-agent/lib/grinder-core-3.9.1.jar, file:/opt/ngrinder-agent/lib/commons-collections-3.2.1.jar, file:/opt/ngrinder-agent/lib/jandex-2.1.3.Final.jar, file:/opt/ngrinder-agent/lib/java-semver-0.9.0.jar, file:/opt/ngrinder-agent/lib/ngrinder-runtime-3.5.6.jar, file:/opt/ngrinder-agent/lib/logback-core-1.2.3.jar, file:/opt/ngrinder-agent/lib/oshi-core-6.1.6.jar, file:/opt/ngrinder-agent/lib/slf4j-api-1.7.30.jar, file:/opt/ngrinder-agent/lib/javassist-3.24.0-GA.jar, file:/opt/ngrinder-agent/lib/groovy-xml-3.0.5.jar, file:/opt/ngrinder-agent/lib/junit-4.13.1.jar, file:/opt/ngrinder-agent/lib/httpcore5-5.0.3.jar])
	at com.sun.jna.NativeLibrary.loadLibrary(NativeLibrary.java:301)
	at com.sun.jna.NativeLibrary.getInstance(NativeLibrary.java:461)
	at com.sun.jna.Library$Handler.<init>(Library.java:192)
	at com.sun.jna.Native.load(Native.java:622)
	at com.sun.jna.Native.load(Native.java:596)
	at com.sun.jna.platform.linux.Udev.<clinit>(Udev.java:37)
	at oshi.hardware.platform.linux.LinuxNetworkIF.queryIfModel(LinuxNetworkIF.java:74)
	at oshi.hardware.platform.linux.LinuxNetworkIF.<init>(LinuxNetworkIF.java:68)
	at oshi.hardware.platform.linux.LinuxNetworkIF.getNetworks(LinuxNetworkIF.java:110)
	at oshi.hardware.platform.linux.LinuxHardwareAbstractionLayer.getNetworkIFs(LinuxHardwareAbstractionLayer.java:92)
	at oshi.hardware.common.AbstractHardwareAbstractionLayer.getNetworkIFs(AbstractHardwareAbstractionLayer.java:104)
	at org.ngrinder.common.util.SystemInfoUtils.<clinit>(SystemInfoUtils.java:60)
	at org.ngrinder.NGrinderAgentStarter.checkDuplicatedRun(NGrinderAgentStarter.java:279)
	at org.ngrinder.NGrinderAgentStarter.main(NGrinderAgentStarter.java:207)
	Suppressed: java.lang.UnsatisfiedLinkError: libudev.so: cannot open shared object file: No such file or directory
		at com.sun.jna.Native.open(Native Method)
		at com.sun.jna.NativeLibrary.loadLibrary(NativeLibrary.java:191)
		... 13 more
	Suppressed: java.lang.UnsatisfiedLinkError: libudev.so: cannot open shared object file: No such file or directory
		at com.sun.jna.Native.open(Native Method)
		at com.sun.jna.NativeLibrary.loadLibrary(NativeLibrary.java:204)
		... 13 more
	Suppressed: java.io.IOException: Native library (linux-x86-64/libudev.so) not found in resource path ([file:/opt/ngrinder-agent/lib/ngrinder-core-3.5.6.jar, file:/opt/ngrinder-agent/lib/ngrinder-runime-3.5.6.jar, file:/opt/ngrinder-agent/lib/logback-classic-1.2.3.jar, file:/opt/ngrinder-agent/lib/hibernate-core-5.4.20.Final.jar, file:/opt/ngrinder-agent/lib/dnsjava-3.2.2.jar, file:/opt/ngrinder-agent/lib/istack-commons-runtime-3.0.11.jar, file:/opt/ngrinder-agent/lib/jaxb-api-2.3.1.jar, file:/opt/ngrinder-agent/lib/byte-buddy-1.10.14.jar, file:/opt/ngrinder-agent/lib/json-20090211.jar, file:/opt/ngrinder-agent/lib/groovy-sql-3.0.5.jar, file:/opt/ngrinder-agent/lib/commons-compress-1.4.1.jar, file:/opt/ngrinder-agent/lib/commons-codec-1.14.jar, file:/opt/ngrinder-agent/lib/grinder-dcr-agent-3.9.1.jar, file:/opt/ngrinder-agent/lib/commons-io-2.6.jar, file:/opt/ngrinder-agent/lib/hamcrest-core-2.2.jar, file:/opt/ngrinder-agent/lib/jboss-logging-3.4.1.Final.jar, file:/opt/ngrinder-agent/lib/jackson-annotations-2.11.2.jar, file:/opt/ngrinder-agent/lib/picocontainer-2.13.6.jar, file:/opt/ngrinder-agent/lib/grinder-http-3.9.1.jar, file:/opt/ngrinder-agent/lib/asm-9.0.jar, file:/opt/ngrinder-agent/lib/ngrinder-core-3.5.6.jar, file:/opt/ngrinder-agent/lib/jaxb-runtime-2.3.3.jar, file:/opt/ngrinder-agent/lib/groovy-json-3.0.5.jar, file:/opt/ngrinder-agent/lib/xz-1.0.jar, file:/opt/ngrinder-agent/lib/jython-standalone-2.7.2.jar, file:/opt/ngrinder-agent/lib/jboss-transaction-api_1.2_spec-1.1.1.Final.jar, file:/opt/ngrinder-agent/lib/httpcore5-h2-5.0.3.jar, file:/opt/ngrinder-agent/lib/jna-platform-5.11.0.jar, file:/opt/ngrinder-agent/lib/jna-5.11.0.jar, file:/opt/ngrinder-agent/lib/classmate-1.5.1.jar, file:/opt/ngrinder-agent/lib/antlr-2.7.7.jar, file:/opt/ngrinder-agent/lib/pf4j-3.0.1.jar, file:/opt/ngrinder-agent/lib/javax.activation-api-1.2.0.jar, file:/opt/ngrinder-agent/lib/jackson-core-2.11.2.jar, file:/opt/ngrinder-agent/lib/groovy-3.0.5.jar, file:/opt/ngrinder-agent/lib/hamcrest-all-1.1.jar, file:/opt/ngrinder-agent/lib/commons-lang-2.6.jar, file:/opt/ngrinder-agent/lib/txw2-2.3.3.jar, file:/opt/ngrinder-agent/lib/hibernate-commons-annotations-5.1.0.Final.jar, file:/opt/ngrinder-agent/lib/jcl-over-slf4j-1.7.30.jar, file:/opt/ngrinder-agent/lib/javax.servlet-api-4.0.1.jar, file:/opt/ngrinder-agent/lib/ngrinder-groovy-3.5.6.jar, file:/opt/ngrinder-agent/lib/dom4j-2.1.3.jar, file:/opt/ngrinder-agent/lib/groovy-datetime-3.0.5.jar, file:/opt/ngrinder-agent/lib/jcommander-1.32.jar, file:/opt/ngrinder-agent/lib/groovy-templates-3.0.5.jar, file:/opt/ngrinder-agent/lib/jackson-databind-2.11.2.jar, file:/opt/ngrinder-agent/lib/javax.persistence-api-2.2.jar, file:/opt/ngrinder-agent/lib/grinder-httpclient-3.9.1.jar, file:/opt/ngrinder-agent/lib/grinder-core-3.9.1.jar, file:/opt/ngrinder-agent/lib/commons-collections-3.2.1.jar, file:/opt/ngrinder-agent/lib/jandex-2.1.3.Final.jar, file:/opt/ngrinder-agent/lib/java-semver-0.9.0.jar, file:/opt/ngrinder-agent/lib/ngrinder-runtime-3.5.6.jar, file:/opt/ngrinder-agent/lib/logback-core-1.2.3.jar, file:/opt/ngrinder-agent/lib/oshi-core-6.1.6.jar, file:/opt/ngrinder-agent/lib/slf4j-api-1.7.30.jar, file:/opt/ngrinder-agent/lib/javassist-3.24.0-GA.jar, file:/opt/ngrinder-agent/lib/groovy-xml-3.0.5.jar, file:/opt/ngrinder-agent/lib/junit-4.13.1.jar, file:/opt/ngrinder-agent/lib/httpcore5-5.0.3.jar])
		at com.sun.jna.Native.extractFromResourcePath(Native.java:1145)
		at com.sun.jna.NativeLibrary.loadLibrary(NativeLibrary.java:275)
		... 13 more
```

</p>
</details>

I changed Dockerfile to install `udev`.
