### PR TITLE
Fix gradle command execution on Oshi 6.x

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/script/handler/GroovyGradleProjectScriptHandler.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/script/handler/GroovyGradleProjectScriptHandler.java
@@ -87,7 +87,7 @@ public class GroovyGradleProjectScriptHandler extends GroovyProjectScriptHandler
 		if (results.isEmpty()) {
 			return false;
 		}
-		return results.stream().noneMatch(str -> str.contains("FAILED"));
+		return results.stream().noneMatch(str -> str.contains("FAILED") || str.contains("ERROR"));
 	}
 
 	@Override

--- a/ngrinder-controller/src/main/java/org/ngrinder/script/handler/GroovyProjectScriptHandler.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/script/handler/GroovyProjectScriptHandler.java
@@ -162,8 +162,11 @@ public abstract class GroovyProjectScriptHandler extends GroovyScriptHandler imp
 		String copyDependenciesCommand = getCopyDependenciesCommand(distDir);
 		processingResult.println("\nCopy dependencies by running '" + copyDependenciesCommand + "'");
 
-		boolean success = isSuccess(runNative(copyDependenciesCommand));
+		log.info("Copy dependencies with command '" + copyDependenciesCommand + "'");
+		List<String> result = runNative(copyDependenciesCommand);
+		log.info("Copy dependencies result: " + result);
 
+		boolean success = isSuccess(result);
 		if (success) {
 			processingResult.printf("\nDependencies in %s was copied.\n", buildFilePathInSVN);
 			log.info(format(perfTest, "Dependencies in {} is copied into {}/lib folder", buildFilePathInSVN, distDir.getAbsolutePath()));

--- a/ngrinder-controller/src/main/java/org/ngrinder/script/handler/GroovyProjectScriptHandler.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/script/handler/GroovyProjectScriptHandler.java
@@ -163,7 +163,7 @@ public abstract class GroovyProjectScriptHandler extends GroovyScriptHandler imp
 		processingResult.println("\nCopy dependencies by running '" + copyDependenciesCommand + "'");
 
 		log.info("Copy dependencies with command '" + copyDependenciesCommand + "'");
-		List<String> result = runNative(copyDependenciesCommand);
+		List<String> result = runNative(copyDependenciesCommand.split(" "), null);
 		log.info("Copy dependencies result: " + result);
 
 		boolean success = isSuccess(result);

--- a/ngrinder-controller/src/main/java/org/ngrinder/starter/InstallationChecker.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/starter/InstallationChecker.java
@@ -64,7 +64,8 @@ public enum InstallationChecker {
 	}
 
 	private boolean isInstalled() {
-		List<String> result = runNative(homePath + installationCheckingCommand);
+		String checkCommand = homePath + installationCheckingCommand;
+		List<String> result = runNative(checkCommand.split(" "), null);
 		return !result.isEmpty();
 	}
 


### PR DESCRIPTION
Recently, nGrinder bumps Oshi from `5.2.2` to `6.1.6`.
And Oshi changes the `runNative()` method to pass environment variables.
`runNative()` method is a wrapper of `Runtime.getRuntime().exec()` that captures the output in a list.

```java
public static List<String> runNative(String[] cmdToRunWithArgs) {
    return runNative(cmdToRunWithArgs, DEFAULT_ENV); // DEFAULT_ENV == "LC_ALL=C"
}
```

This change makes executing gradle goes wrong. So, I changed to pass nothing as environment variable. 