### PR TITLE
Fix revision and target hosts reset

### DIFF
--- a/ngrinder-frontend/src/js/components/perftest/detail/Config.vue
+++ b/ngrinder-frontend/src/js/components/perftest/detail/Config.vue
@@ -515,7 +515,6 @@
             }
 
             this.$nextTick(() => {
-                this.$refs.scriptSelect.selectValue(selectedScript);
                 this.$validator.validate('scriptName');
             });
         }


### PR DESCRIPTION
There is a bug related to Select2 version up.

* Revision is always set as `HEAD` whenever creating a new test or checking the test alread done.
* Target hosts field is always set as equal to script's target hosts setting. 
   Setting the target hosts in perftest config menu is not affected.

These two bugs are caused by triggering `change` event at the initial rendering.
Fix these bugs by removing the selection of the initial script selecting.