### PR TITLE
Add warning message when running without tmpdir property

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/common/constant/ConsoleColorConstants.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/common/constant/ConsoleColorConstants.java
@@ -1,0 +1,7 @@
+package org.ngrinder.common.constant;
+
+public interface ConsoleColorConstants {
+	String CONSOLE_COLOR_YELLOW = "\033[0;33m";
+	String CONSOLE_COLOR_RED = "\033[0;31m";
+	String CONSOLE_COLOR_RESET = "\033[0m";
+}

--- a/ngrinder-controller/src/main/java/org/ngrinder/starter/InstallationChecker.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/starter/InstallationChecker.java
@@ -23,6 +23,8 @@ package org.ngrinder.starter;
 import java.util.List;
 
 import static java.lang.System.*;
+import static org.ngrinder.common.constant.ConsoleColorConstants.CONSOLE_COLOR_RESET;
+import static org.ngrinder.common.constant.ConsoleColorConstants.CONSOLE_COLOR_YELLOW;
 import static org.ngrinder.script.handler.GroovyGradleProjectScriptHandler.GRADLE_HOME_ENV_NAME;
 import static org.ngrinder.script.handler.GroovyMavenProjectScriptHandler.MAVEN_HOME_ENV_NAME;
 import static oshi.util.ExecutingCommand.runNative;
@@ -40,9 +42,6 @@ public enum InstallationChecker {
 		"Maven isn't installed, You can't run Maven groovy scripts. Please install Maven and set MAVEN_HOME.    "),
 	GRADLE(GRADLE_HOME_ENV_NAME, "gradle -version",
 		"Gradle isn't installed, You can't run Gradle groovy scripts. Please install Gradle and set GRADLE_HOME.");
-
-	private static final String CONSOLE_COLOR_YELLOW = "\033[0;33m";
-	private static final String CONSOLE_COLOR_RESET = "\033[0m";
 
 	private final String homePath;
 	private final String installationCheckingCommand;

--- a/ngrinder-controller/src/main/java/org/ngrinder/starter/NGrinderControllerStarter.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/starter/NGrinderControllerStarter.java
@@ -246,18 +246,15 @@ public class NGrinderControllerStarter extends SpringBootServletInitializer {
 	}
 
 	private static void checkTmpDirProperty() {
-		String userHome = System.getProperty("user.home");
-		String ngrinderHome = Config.getUserHome();
 		String javaTmpDir = System.getProperty("java.io.tmpdir");
+		String systemTmpDir = System.getenv("TMPDIR");
 
-		if (!javaTmpDir.startsWith(userHome) && !javaTmpDir.startsWith(ngrinderHome)) {
-			System.out.print(CONSOLE_COLOR_RED);
-			System.out.println("####################################################################################################################");
-			System.out.println("# ERROR                                                                                                            #");
-			System.out.println("# Wrong runtime option. Please put tmpdir property like following.                                                 #");
-			System.out.println("# `java -Djava.io.tmpdir=${NGRINDER_HOME}/lib -jar ngrinder-controller.war`                                        #");
-			System.out.println("####################################################################################################################");
-			System.out.print(CONSOLE_COLOR_RESET);
+		if (javaTmpDir.equals(systemTmpDir)) {
+			System.err.print(CONSOLE_COLOR_RED);
+			System.err.println("ERROR");
+			System.err.println("Please set `java.io.tmpdir` property like following. tmpdir should be different from the OS default tmpdir.");
+			System.err.println("`java -Djava.io.tmpdir=${NGRINDER_HOME}/lib -jar ngrinder-controller.war`");
+			System.err.print(CONSOLE_COLOR_RESET);
 			System.exit(1);
 		}
 	}

--- a/ngrinder-controller/src/main/java/org/ngrinder/starter/NGrinderControllerStarter.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/starter/NGrinderControllerStarter.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static java.lang.System.out;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.ngrinder.common.constant.ClusterConstants.*;
@@ -49,6 +50,9 @@ import static org.ngrinder.common.constant.DatabaseConstants.PROP_DATABASE_URL;
 )
 @Parameters(separators = "= ")
 public class NGrinderControllerStarter extends SpringBootServletInitializer {
+
+	private static final String CONSOLE_COLOR_YELLOW = "\033[0;33m";
+	private static final String CONSOLE_COLOR_RESET = "\033[0m";
 
 	@Parameters(separators = "= ")
 	enum ClusterMode {
@@ -203,6 +207,7 @@ public class NGrinderControllerStarter extends SpringBootServletInitializer {
 	}
 
 	public static void main(String[] args) {
+		checkTmpDirProperty();
 		NGrinderControllerStarter server = new NGrinderControllerStarter();
 		JCommander commander = new JCommander(server);
 		commander.setAcceptUnknownOptions(true);
@@ -241,6 +246,23 @@ public class NGrinderControllerStarter extends SpringBootServletInitializer {
 		System.getProperties().putAll(server.params);
 		cleanupPreviouslyUnpackedFolders();
 		SpringApplication.run(NGrinderControllerStarter.class, args);
+	}
+
+	private static void checkTmpDirProperty() {
+		String javaTmpDir = System.getProperty("java.io.tmpdir");
+		String systemTmpDir = System.getenv("TMPDIR");
+		if (javaTmpDir.equals(systemTmpDir)) {
+			System.out.print(CONSOLE_COLOR_YELLOW);
+			System.out.println("####################################################################################################################");
+			System.out.println("# WARNING                                                                                                          #");
+			System.out.println("# If you run the ngrinder-controller as SpringBoot JAR without specifying 'java.io.tmpdir' system property,        #");
+			System.out.println("# related library files could be unintentionally missing and you could encounter unexpected errors.                #");
+			System.out.println("# You must run the ngrinder-controller with specifying 'java.io.tmpdir' system property.                           #");
+			System.out.println("#   ex) java -Djava.io.tmpdir=/home/user/.ngrinder/lib -jar ngrinder-controller.war                                #");
+			System.out.println("####################################################################################################################");
+			System.out.print(CONSOLE_COLOR_RESET);
+			System.exit(1);
+		}
 	}
 
 	private static String getRunningCommand() {

--- a/ngrinder-controller/src/main/java/org/ngrinder/starter/NGrinderControllerStarter.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/starter/NGrinderControllerStarter.java
@@ -34,10 +34,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static java.lang.System.out;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.ngrinder.common.constant.ClusterConstants.*;
+import static org.ngrinder.common.constant.ConsoleColorConstants.CONSOLE_COLOR_RED;
+import static org.ngrinder.common.constant.ConsoleColorConstants.CONSOLE_COLOR_RESET;
 import static org.ngrinder.common.constant.ControllerConstants.PROP_CONTROLLER_CONTROLLER_PORT;
 import static org.ngrinder.common.constant.DatabaseConstants.PROP_DATABASE_TYPE;
 import static org.ngrinder.common.constant.DatabaseConstants.PROP_DATABASE_URL;
@@ -50,10 +51,6 @@ import static org.ngrinder.common.constant.DatabaseConstants.PROP_DATABASE_URL;
 )
 @Parameters(separators = "= ")
 public class NGrinderControllerStarter extends SpringBootServletInitializer {
-
-	private static final String CONSOLE_COLOR_YELLOW = "\033[0;33m";
-	private static final String CONSOLE_COLOR_RESET = "\033[0m";
-
 	@Parameters(separators = "= ")
 	enum ClusterMode {
 		none {
@@ -249,16 +246,16 @@ public class NGrinderControllerStarter extends SpringBootServletInitializer {
 	}
 
 	private static void checkTmpDirProperty() {
+		String userHome = System.getProperty("user.home");
+		String ngrinderHome = Config.getUserHome();
 		String javaTmpDir = System.getProperty("java.io.tmpdir");
-		String systemTmpDir = System.getenv("TMPDIR");
-		if (javaTmpDir.equals(systemTmpDir)) {
-			System.out.print(CONSOLE_COLOR_YELLOW);
+
+		if (!javaTmpDir.startsWith(userHome) && !javaTmpDir.startsWith(ngrinderHome)) {
+			System.out.print(CONSOLE_COLOR_RED);
 			System.out.println("####################################################################################################################");
-			System.out.println("# WARNING                                                                                                          #");
-			System.out.println("# If you run the ngrinder-controller as SpringBoot JAR without specifying 'java.io.tmpdir' system property,        #");
-			System.out.println("# related library files could be unintentionally missing and you could encounter unexpected errors.                #");
-			System.out.println("# You must run the ngrinder-controller with specifying 'java.io.tmpdir' system property.                           #");
-			System.out.println("#   ex) java -Djava.io.tmpdir=/home/user/.ngrinder/lib -jar ngrinder-controller.war                                #");
+			System.out.println("# ERROR                                                                                                            #");
+			System.out.println("# Wrong runtime option. Please put tmpdir property like following.                                                 #");
+			System.out.println("# `java -Djava.io.tmpdir=${NGRINDER_HOME}/lib -jar ngrinder-controller.war`                                        #");
 			System.out.println("####################################################################################################################");
 			System.out.print(CONSOLE_COLOR_RESET);
 			System.exit(1);

--- a/ngrinder-controller/src/main/java/org/ngrinder/starter/NGrinderControllerStarter.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/starter/NGrinderControllerStarter.java
@@ -247,9 +247,12 @@ public class NGrinderControllerStarter extends SpringBootServletInitializer {
 
 	private static void checkTmpDirProperty() {
 		String javaTmpDir = System.getProperty("java.io.tmpdir");
-		String systemTmpDir = System.getenv("TMPDIR");
+		String osTmpDir = System.getenv("TMPDIR");
+		if (osTmpDir == null) {
+			osTmpDir = "";
+		}
 
-		if (javaTmpDir.equals(systemTmpDir)) {
+		if (javaTmpDir.equals(osTmpDir)) {
 			System.err.print(CONSOLE_COLOR_RED);
 			System.err.println("ERROR");
 			System.err.println("Please set `java.io.tmpdir` property like following. tmpdir should be different from the OS default tmpdir.");


### PR DESCRIPTION
resolve: #848

If running on tomcat, `NGrinderControllerStarter.main()` will not be invoked.
If running on SpringBoot JAR, check the `tmpdir` system property and exit if the property is not specified.

Warning message shows like this.
![image](https://user-images.githubusercontent.com/10591327/209637709-c98bd83b-b6fa-4217-8081-d0ba787bb256.png)
