### PR TITLE
Add description about agent connection port to docker README.md

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -42,6 +42,8 @@ Port information:
 
 * __80__: Default controller web UI port.
 
+* __16001__: Controller port for agent connection.
+
 * __9010-9019__: agents connect to the controller cluster through these ports.
 
 * __12000-12029__: controllers allocate stress tests through these ports.


### PR DESCRIPTION
I want to add description about purpose of 16001 port.
I referenced the `org.ngrinder.starter.NGrinderControllerStarter` class of ngrinder-controller module.