### PR TITLE
Fix to use controller.host property for ip resolve

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/common/constant/ControllerConstants.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/common/constant/ControllerConstants.java
@@ -53,7 +53,7 @@ public interface ControllerConstants {
 	String PROP_CONTROLLER_FRONT_PAGE_QNA_RSS = "controller.front_page_qna_rss";
 	String PROP_CONTROLLER_FRONT_PAGE_RESOURCES_MORE_URL = "controller.front_page_resources_more_url";
 	String PROP_CONTROLLER_HELP_URL = "controller.help_url";
-	String PROP_CONTROLLER_IP = "controller.ip";
+	String PROP_CONTROLLER_HOST = "controller.host";
 	String PROP_CONTROLLER_MAX_AGENT_PER_TEST = "controller.max_agent_per_test";
 	String PROP_CONTROLLER_MAX_CONCURRENT_TEST = "controller.max_concurrent_test";
 	String PROP_CONTROLLER_MAX_RUN_COUNT = "controller.max_run_count";

--- a/ngrinder-controller/src/main/java/org/ngrinder/infra/config/Config.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/infra/config/Config.java
@@ -703,7 +703,7 @@ public class Config extends AbstractConfig implements ControllerConstants, Clust
 		if (cluster) {
 			return StringUtils.trimToEmpty(getClusterProperties().getProperty(PROP_CLUSTER_HOST));
 		} else {
-			return StringUtils.trimToEmpty(getControllerProperties().getProperty(PROP_CONTROLLER_IP));
+			return StringUtils.trimToEmpty(getControllerProperties().getProperty(PROP_CONTROLLER_HOST));
 		}
 	}
 

--- a/ngrinder-controller/src/main/resources/controller-properties.map
+++ b/ngrinder-controller/src/main/resources/controller-properties.map
@@ -17,7 +17,7 @@ controller.monitor_port,13243,monitor.listen.port
 controller.url,,ngrinder.http.url,http.url
 controller.console_port_base,12000,ngrinder.console.portbase
 controller.controller_port,16001,ngrinder.agent.control.port
-controller.ip,,ngrinder.controller.ipaddress,ngrinder.controller.ip
+controller.host,,controller.ip,ngrinder.controller.ipaddress,ngrinder.controller.ip
 controller.validation_timeout,100,ngrinder.validation.timeout
 controller.enable_agent_auto_approval,true,
 controller.enable_script_console,false,

--- a/ngrinder-core/src/main/java/net/grinder/util/NetworkUtils.java
+++ b/ngrinder-core/src/main/java/net/grinder/util/NetworkUtils.java
@@ -226,7 +226,7 @@ public abstract class NetworkUtils {
 				if (!inetAddress.isReachable(MAX_REACHABLE_TIMEOUT)) {
 					processException(
 						"Can not check available ports because given local IP address '" + ip + "' is unreachable. " +
-							"Please check the `/etc/hosts` file or manually specify the local IP address in `${NGRINDER_HOME}/system.conf`."
+							"Specify controller.host property in `${NGRINDER_HOME}/system.conf`."
 					);
 				}
 			} catch (SecurityException | IOException e) {


### PR DESCRIPTION
in the system.conf, controller.host field exists but is not used. 
(Instead old property (controller.ip) was used..)
Fix this....