### PR TITLE
Change yaml parser to yamlbeans

### DIFF
--- a/ngrinder-controller/build.gradle
+++ b/ngrinder-controller/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation (group: "jaxen", name: "jaxen", version: "1.1.4")
     implementation (group: "com.beust", name: "jcommander", version: "1.32")
     implementation (group: "org.pf4j", name: "pf4j", version: "3.0.1")
-    implementation (group: "org.yaml", name: "snakeyaml", version: "1.25")
+    implementation (group: "com.esotericsoftware.yamlbeans", name: "yamlbeans", version: "1.17")
     implementation (group: "commons-collections", name: "commons-collections", version: "3.2.1")
     implementation (group: "org.reflections", name: "reflections", version: "0.9.9")
     implementation (group: "com.hazelcast", name: "hazelcast", version: hazelcast_version)

--- a/ngrinder-controller/src/main/java/org/ngrinder/script/service/GitHubFileEntryService.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/script/service/GitHubFileEntryService.java
@@ -278,7 +278,7 @@ public class GitHubFileEntryService {
 		return getAllGithubConfig(gitConfigYaml);
 	}
 
-	protected Set<GitHubConfig> getAllGithubConfig(FileEntry gitConfigYaml) {
+	private Set<GitHubConfig> getAllGithubConfig(FileEntry gitConfigYaml) {
 		Set<GitHubConfig> gitHubConfig = new HashSet<>();
 		try (YamlReader reader = new YamlReader(gitConfigYaml.getContent())) {
 			Map<String, Object> gitConfigMap = cast(reader.read());

--- a/ngrinder-controller/src/test/java/org/ngrinder/script/service/GitHubFileEntryServiceTest.java
+++ b/ngrinder-controller/src/test/java/org/ngrinder/script/service/GitHubFileEntryServiceTest.java
@@ -1,0 +1,88 @@
+package org.ngrinder.script.service;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.ngrinder.AbstractNGrinderTransactionalTest;
+import org.ngrinder.common.util.CompressionUtils;
+import org.ngrinder.model.User;
+import org.ngrinder.script.model.FileEntry;
+import org.ngrinder.script.model.GitHubConfig;
+import org.ngrinder.script.repository.MockFileEntityRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
+
+public class GitHubFileEntryServiceTest extends AbstractNGrinderTransactionalTest {
+
+    private static final String GITHUB_CONFIG_NAME = ".gitconfig.yml";
+
+    @Autowired
+    private GitHubFileEntryService gitHubFileEntryService;
+
+    @Autowired
+    private MockFileEntityRepository mockFileEntityRepository;
+
+    @Before
+    public void before() throws IOException {
+        File file = new File(System.getProperty("java.io.tmpdir"), "repo");
+        FileUtils.deleteQuietly(file);
+        CompressionUtils.unzip(new ClassPathResource("TEST_USER.zip").getFile(), file);
+        mockFileEntityRepository.setUserRepository(new File(file, getTestUser().getUserId()));
+    }
+
+    @Test
+    public void getAllGitHubConfig() throws Exception {
+        User testUser = getTestUser();
+
+        FileEntry fileEntry = new FileEntry();
+        fileEntry.setContent("name: My Github Config\n" +
+                "owner: naver\n" +
+                "repo: ngrinder\n" +
+                "access-token: e1a47e652762b60a...3ddc0713b07g13k\n" +
+                "---\n" +
+                "name: Another Config\n" +
+                "owner: naver\n" +
+                "repo: pinpoint\n" +
+                "access-token: t9a47e6ff262b60a...3dac0713b07e82a\n" +
+                "branch: feature/add-ngrinder-scripts\n" +
+                "base-url: https://api.mygithub.com\n" +
+                "script-root: ngrinder-scripts\n"
+        );
+        fileEntry.setEncoding("UTF-8");
+        fileEntry.setPath(GITHUB_CONFIG_NAME);
+        fileEntry.setDescription("for unit test");
+        mockFileEntityRepository.save(testUser, fileEntry, fileEntry.getEncoding());
+
+        Set<GitHubConfig> gitHubConfigs = gitHubFileEntryService.getAllGitHubConfig(testUser);
+
+        assertThat(gitHubConfigs.size(), is(2));
+        assertThat(
+                gitHubConfigs,
+                hasItems(
+                        GitHubConfig.builder()
+                                .name("My Github Config")
+                                .owner("naver")
+                                .repo("ngrinder")
+                                .accessToken("e1a47e652762b60a...3ddc0713b07g13k")
+                                .build(),
+                        GitHubConfig.builder()
+                                .name("Another Config")
+                                .owner("naver")
+                                .repo("pinpoint")
+                                .accessToken("t9a47e6ff262b60a...3dac0713b07e82a")
+                                .branch("feature/add-ngrinder-scripts")
+                                .baseUrl("https://api.mygithub.com")
+                                .scriptRoot("ngrinder-scripts")
+                                .build()
+                )
+        );
+    }
+}


### PR DESCRIPTION
snakeyaml 1.x has security vulnerability. So, I tried to bump it up to 2.x. But, the snakeyaml is related to spring framework also. When the snakeyaml is found on classpath, spring try to use the given snakeyaml to handling yaml property file.

Most of spring-boot versions are depend on snakeyaml 1.x except latest version of spring-boot. I think that upgrade spring-boot to latest version will take long time. So, just change the yaml parser to [yamlbeans](https://github.com/EsotericSoftware/yamlbeans) that has most stars library in [yaml official website](https://yaml.org/) except snakeyaml.


 