### PR TITLE
Fix failing to call mvn or gradle at MAVEN_HOME, GRADLE_HOME respectively in Windows (Resolves #975)

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/starter/InstallationChecker.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/starter/InstallationChecker.java
@@ -20,6 +20,9 @@
  */
 package org.ngrinder.starter;
 
+import com.sun.jna.Platform;
+
+import java.io.File;
 import java.util.List;
 
 import static java.lang.System.*;
@@ -38,20 +41,19 @@ import static oshi.util.ExecutingCommand.runNative;
  * */
 public enum InstallationChecker {
 
-	MAVEN(MAVEN_HOME_ENV_NAME, "mvn -version",
+	MAVEN(MAVEN_HOME_ENV_NAME, Platform.isWindows() ? "mvn.cmd -version" : "mvn -version",
 		"Maven isn't installed, You can't run Maven groovy scripts. Please install Maven and set MAVEN_HOME.    "),
-	GRADLE(GRADLE_HOME_ENV_NAME, "gradle -version",
+	GRADLE(GRADLE_HOME_ENV_NAME, Platform.isWindows() ? "gradle.bat -version" : "gradle -version",
 		"Gradle isn't installed, You can't run Gradle groovy scripts. Please install Gradle and set GRADLE_HOME.");
 
-	private final String homePath;
+	private final String homeEnvName;
 	private final String installationCheckingCommand;
 	private final String warningMessage;
 
 	InstallationChecker(String homeEnvName, String installationCheckingCommand, String warningMessage) {
+		this.homeEnvName = homeEnvName;
 		this.warningMessage = warningMessage;
 		this.installationCheckingCommand = installationCheckingCommand;
-
-		homePath = getenv(homeEnvName) == null ? "" : getenv(homeEnvName) + "/bin/";
 	}
 
 	public static void checkAll() {
@@ -63,6 +65,8 @@ public enum InstallationChecker {
 	}
 
 	private boolean isInstalled() {
+		String env = getenv(homeEnvName);
+		String homePath = env == null ? "" : env + File.separator +  "bin" + File.separator;
 		String checkCommand = homePath + installationCheckingCommand;
 		List<String> result = runNative(checkCommand.split(" "), null);
 		return !result.isEmpty();

--- a/ngrinder-controller/src/test/java/org/ngrinder/starter/InstallationCheckerTest.java
+++ b/ngrinder-controller/src/test/java/org/ngrinder/starter/InstallationCheckerTest.java
@@ -1,0 +1,11 @@
+package org.ngrinder.starter;
+
+import org.junit.Test;
+
+public class InstallationCheckerTest {
+
+	@Test
+	public void checkInstalled() {
+		InstallationChecker.checkAll();
+	}
+}


### PR DESCRIPTION
There were two major factors causing this bug.

1. Calling `System.getenv()` on initializing enums was failed on Windows.
2. Getting the standard output of the process using `oshi.util.ExecutingCommand.runNative()` was failed on Windows due to Linux-specific command scripts.

### Changes
1. Changed the time calling `System.getenv()` after initializing.
2. Set OS specific command scripts checking installation using `com.sun.jna.Platform.isWindows()`.

Since `com.sun.jna.Platform` sets the static values of current OS on start, no needed to call `System.getProperty("os.name")` again.
But considered that the dependency including `com.sun.jna.Platform` may be removed in future, it could be the best option to check by calling `System.getProperty("os.name")`.