### PR TITLE
Fix Javadoc for getCollectTimeInLong method

### DIFF
--- a/ngrinder-core/src/main/java/org/ngrinder/common/util/DateUtils.java
+++ b/ngrinder-core/src/main/java/org/ngrinder/common/util/DateUtils.java
@@ -49,8 +49,8 @@ public abstract class DateUtils {
 	/**
 	 * Get the time in long format : "yyyyMMddHHmmss".
 	 *
-	 * @param date	date to be format
-	 * @return time time in format of long type
+	 * @param date	date to be formatted
+	 * @return time in format of long type
 	 */
 	public static long getCollectTimeInLong(Date date) {
 		SimpleDateFormat collectTimeFormat = new SimpleDateFormat("yyyyMMddHHmmss");


### PR DESCRIPTION
This pull request fixes the Javadoc comment for the getCollectTimeInLong method.
Key changes:

Corrected the grammatical error in the @param tag description: "date to be format" → "date to be formatted"
Clarified the return value description
Removed redundant information to make the comment more concise

Captures:
<img width="414" alt="스크린샷 2024-10-02 오후 6 29 56" src="https://github.com/user-attachments/assets/0e4491a4-178c-48a1-aedc-c377f8ea496b">
<img width="622" alt="스크린샷 2024-10-02 오후 6 30 04" src="https://github.com/user-attachments/assets/88658199-e4cf-4026-8078-972a83bb5579">
<img width="362" alt="스크린샷 2024-10-02 오후 6 30 17" src="https://github.com/user-attachments/assets/409064fb-3cb9-4a18-b0f0-e7e8e67a9b90">
