### PR TITLE
Fix: XSS Vulnerability in File Upload Descriptions

### DIFF
--- a/ngrinder-controller/src/main/java/org/ngrinder/script/controller/FileEntryApiController.java
+++ b/ngrinder-controller/src/main/java/org/ngrinder/script/controller/FileEntryApiController.java
@@ -49,6 +49,7 @@ import org.springframework.http.ContentDisposition;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import com.nhncorp.lucy.security.xss.XssPreventer;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
@@ -282,6 +283,7 @@ public class FileEntryApiController {
 							 @RequestParam String description,
 							 @RequestParam("uploadFile") MultipartFile file) {
 		try {
+			description = XssPreventer.escape(description);
 			upload(user, path, description, file);
 		} catch (IOException e) {
 			LOG.error("Error while getting file content: {}", e.getMessage(), e);
@@ -290,6 +292,8 @@ public class FileEntryApiController {
 	}
 
 	private void upload(User user, String path, String description, MultipartFile file) throws IOException {
+		description = XssPreventer.escape(description);
+
 		FileEntry fileEntry = new FileEntry();
 		fileEntry.setContentBytes(file.getBytes());
 		fileEntry.setDescription(description);


### PR DESCRIPTION
### **Description**
This PR addresses a cross-site scripting vulnerability by implementing XssPreventer.escape() on all description parameters during file uploads. 
[Fix ](https://github.com/naver/ngrinder/commit/2e09d20fda1edbae3d166f408f0d2666439403f1)was done previously in a separate controller file but not applied here.

### **References**
Related fix [commit 2e09d20](https://github.com/naver/ngrinder/commit/2e09d20fda1edbae3d166f408f0d2666439403f1).


